### PR TITLE
fix: remove unsupported anyOf from execute_custom_rules schema

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -281,7 +281,7 @@ class TechDebtServer {
               },
               language: {
                 type: 'string',
-                description: 'Programming language for filtering rules',
+                description: 'Optional: programming language for filtering rules',
               },
             },
             required: [],


### PR DESCRIPTION
Closes #62

## Summary
- The Claude API rejects tool input schemas that use `oneOf`, `allOf`, or `anyOf` at the top level
- The `execute_custom_rules` tool used a top-level `anyOf` to enforce that either `path` or `code` must be provided
- Removed the `anyOf` and rely on the existing runtime validation (handler already returns a clear error when neither is provided)
- Moved the constraint into the tool description so LLMs still understand the requirement

## Test plan
- [x] Verify the MCP server starts without errors
- [x] Call `execute_custom_rules` with `path` only — should work
- [x] Call `execute_custom_rules` with `code` only — should work
- [x] Call `execute_custom_rules` with neither — should return error message
- [x] Verify Claude Code no longer returns a 400 error when loading tools