### PR TITLE
Add one-click install badges with IDE deeplinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ code --add-mcp '{"name":"tech-debt-mcp","command":"npx","args":["-y","tech-debt-
 <details>
 <summary><img src="https://img.shields.io/badge/Cursor-Install%20Server-26251E?logo=cursor&logoColor=F7F7F4" alt="Cursor: Install Server"></summary>
 
+**<a href="cursor://anysphere.cursor-deeplink/mcp/install?name=tech-debt-mcp&config=eyJjb21tYW5kIjoibnB4IC15IHRlY2gtZGVidC1tY3AifQ==">One-Click Install</a>**
+
 **Cursor** (via Terminal):
 
 ```sh
@@ -70,24 +72,6 @@ claude mcp add tech-debt-mcp -- npx -y tech-debt-mcp
 ```
 
 **Claude Desktop** — add to your `claude_desktop_config.json`:
-
-```json
-{
-  "mcpServers": {
-    "tech-debt-mcp": {
-      "command": "npx",
-      "args": ["-y", "tech-debt-mcp"]
-    }
-  }
-}
-```
-
-</details>
-
-<details>
-<summary><img src="https://img.shields.io/badge/GitHub_Copilot-Install%20Server-24292E?logo=githubcopilot&logoColor=f5f5f5" alt="GitHub Copilot: Install Server"></summary>
-
-Add to your MCP settings configuration (e.g. `mcp.json`):
 
 ```json
 {
@@ -123,7 +107,7 @@ Add to your Windsurf MCP configuration (`~/.codeium/windsurf/mcp_config.json`):
 <details>
 <summary><img src="https://img.shields.io/badge/JetBrains-Install%20Server-FF0007?logo=jetbrains&logoColor=f5f5f5" alt="JetBrains: Install Server"></summary>
 
-Add to your project's `.mcp.json`:
+Via **AI Assistant** — open **Settings > Tools > AI Assistant > Model Context Protocol (MCP)**, click **+**, select **As JSON**, and paste:
 
 ```json
 {
@@ -137,6 +121,39 @@ Add to your project's `.mcp.json`:
 ```
 
 </details>
+
+<details>
+<summary><img src="https://img.shields.io/badge/Xcode-Install%20Server-147EFB?logo=xcode&logoColor=f5f5f5" alt="Xcode: Install Server"></summary>
+
+Via **GitHub Copilot for Xcode** — open Settings > MCP tab > Edit Config (`mcp.json`):
+
+```json
+{
+  "servers": {
+    "tech-debt-mcp": {
+      "command": "npx",
+      "args": ["-y", "tech-debt-mcp"]
+    }
+  }
+}
+```
+
+</details>
+
+### Manual Setup
+
+Add to your MCP client config:
+
+```json
+{
+  "mcpServers": {
+    "tech-debt-mcp": {
+      "command": "npx",
+      "args": ["-y", "tech-debt-mcp"]
+    }
+  }
+}
+```
 
 ### Option 1: From npm (Recommended)
 


### PR DESCRIPTION
## Summary

- Add collapsible install badge sections for **7 MCP clients**: VS Code, Cursor, Claude (Code + Desktop), Windsurf, JetBrains, and Xcode
- Each section renders a shields.io badge as the clickable summary, expanding to show verified setup instructions
- Replace broken `mcpbadge.dev` badge with shields.io MCP badge
- Replace outdated "Usage with GitHub Copilot" section (which required global install) with `npx`-based configs
- Remove self-hosted SVG badge files — all badges now use shields.io URLs
- Add generic "Manual Setup" section for unlisted clients

Closes #65

## Details

### Badges
- Uses **shields.io** URLs for universal rendering (works on GitHub and npm)
- Previously used self-hosted SVGs in `.github/badges/`, but switched to shields.io to avoid 404s before merge

### Supported Clients
- **VS Code**: One-click install link + terminal command
- **Cursor**: One-click install link + terminal command
- **Claude**: Combined section — Claude Code (terminal) + Claude Desktop (config file)
- **Windsurf**: `~/.codeium/windsurf/mcp_config.json` config
- **JetBrains**: Via AI Assistant settings UI (`mcpServers` format)
- **Xcode**: Via GitHub Copilot for Xcode (`servers` format)
- **Manual Setup**: Generic `mcpServers` config for any other client

### npm compatibility
- Confirmed `<details>`, `<summary>`, and `<img>` tags are all in npm's allowed tags list
- `<picture>` tag is NOT supported on npm — avoided intentionally

### Structure
Each IDE section is a self-contained `<details>` block with:
- Badge image as `<summary>` (renders as clickable expander)
- Bold-formatted labels with consistent styling
- All configs use `npx -y tech-debt-mcp` (no global install required)

## Test plan

- [x] Badges render correctly on GitHub (shields.io)
- [x] Confirmed npm rendering compatibility (`details`/`summary`/`img` allowed)
- [x] Verified config formats against official docs for each client
- [ ] Verify badges render on npmjs.com after publish