### PR TITLE
docs: use @latest in npx commands for fresh package resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@ A Model Context Protocol (MCP) server for analyzing technical debt across multip
 <details>
 <summary><img src="https://img.shields.io/badge/VS_Code-Install%20Server-007ACC?logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZD0iTTIzLjE1IDIuNTg3IDE4LjIxLjIxYTEuNDk0IDEuNDk0IDAgMCAwLTEuNzA1LjI5bC05LjQ2IDguNjMtNC4xMi0zLjEyOGEuOTk5Ljk5OSAwIDAgMC0xLjI3Ni4wNTdMLjMyNyA3LjI2MUExIDEgMCAwIDAgMCA4LjA2OGwzLjU5MiAzLjI5M0wwIDEzLjYxNmExIDEgMCAwIDAgLjMyNy44MDdsMS4zMTEgMS4zMTFhLjk5OS45OTkgMCAwIDAgMS4yNzYuMDU3bDQuMTItMy4xMjggOS40NiA4LjYzYTEuNDkyIDEuNDkyIDAgMCAwIDEuNzA0LjI5bDQuOTQyLTIuMzc3QTEuNSAxLjUgMCAwIDAgMjQgMTguMDE0VjUuOTg2YTEuNSAxLjUgMCAwIDAtLjg1LTEuMzk5ek0xOC41IDE2LjEyIDkuNDEgMTEuMzYxbDkuMDktNC43NTh6IiBmaWxsPSIjZmZmIi8+PC9zdmc+" alt="VS Code: Install Server"></summary>
 
-**[One-Click Install](https://insiders.vscode.dev/redirect/mcp/install?name=tech-debt-mcp&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22tech-debt-mcp%22%5D%7D)**
+**[One-Click Install](https://insiders.vscode.dev/redirect/mcp/install?name=tech-debt-mcp&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22tech-debt-mcp%40latest%22%5D%7D)**
 
 **VS Code** (via Terminal):
 
 ```sh
-code --add-mcp '{"name":"tech-debt-mcp","command":"npx","args":["-y","tech-debt-mcp"]}'
+code --add-mcp '{"name":"tech-debt-mcp","command":"npx","args":["-y","tech-debt-mcp@latest"]}'
 ```
 
 </details>
@@ -54,12 +54,12 @@ code --add-mcp '{"name":"tech-debt-mcp","command":"npx","args":["-y","tech-debt-
 <details>
 <summary><img src="https://img.shields.io/badge/Cursor-Install%20Server-26251E?logo=cursor&logoColor=F7F7F4" alt="Cursor: Install Server"></summary>
 
-**<a href="cursor://anysphere.cursor-deeplink/mcp/install?name=tech-debt-mcp&config=eyJjb21tYW5kIjoibnB4IC15IHRlY2gtZGVidC1tY3AifQ==">One-Click Install</a>**
+**<a href="cursor://anysphere.cursor-deeplink/mcp/install?name=tech-debt-mcp&config=eyJjb21tYW5kIjoibnB4IC15IHRlY2gtZGVidC1tY3BAbGF0ZXN0In0=">One-Click Install</a>**
 
 **Cursor** (via Terminal):
 
 ```sh
-cursor --add-mcp '{"name":"tech-debt-mcp","command":"npx -y tech-debt-mcp"}'
+cursor --add-mcp '{"name":"tech-debt-mcp","command":"npx -y tech-debt-mcp@latest"}'
 ```
 
 </details>
@@ -70,7 +70,7 @@ cursor --add-mcp '{"name":"tech-debt-mcp","command":"npx -y tech-debt-mcp"}'
 **Claude Code** (via Terminal):
 
 ```sh
-claude mcp add tech-debt-mcp -- npx -y tech-debt-mcp
+claude mcp add tech-debt-mcp -- npx -y tech-debt-mcp@latest
 ```
 
 **Claude Desktop** — add to your `claude_desktop_config.json`:
@@ -80,7 +80,7 @@ claude mcp add tech-debt-mcp -- npx -y tech-debt-mcp
   "mcpServers": {
     "tech-debt-mcp": {
       "command": "npx",
-      "args": ["-y", "tech-debt-mcp"]
+      "args": ["-y", "tech-debt-mcp@latest"]
     }
   }
 }
@@ -98,7 +98,7 @@ Add to your Windsurf MCP configuration (`~/.codeium/windsurf/mcp_config.json`):
   "mcpServers": {
     "tech-debt-mcp": {
       "command": "npx",
-      "args": ["-y", "tech-debt-mcp"]
+      "args": ["-y", "tech-debt-mcp@latest"]
     }
   }
 }
@@ -116,7 +116,7 @@ Via **AI Assistant** — open **Settings > Tools > AI Assistant > Model Context 
   "mcpServers": {
     "tech-debt-mcp": {
       "command": "npx",
-      "args": ["-y", "tech-debt-mcp"]
+      "args": ["-y", "tech-debt-mcp@latest"]
     }
   }
 }
@@ -134,7 +134,7 @@ Via **GitHub Copilot for Xcode** — open Settings > MCP tab > Edit Config (`mcp
   "servers": {
     "tech-debt-mcp": {
       "command": "npx",
-      "args": ["-y", "tech-debt-mcp"]
+      "args": ["-y", "tech-debt-mcp@latest"]
     }
   }
 }
@@ -151,7 +151,7 @@ Add to your MCP client config:
   "mcpServers": {
     "tech-debt-mcp": {
       "command": "npx",
-      "args": ["-y", "tech-debt-mcp"]
+      "args": ["-y", "tech-debt-mcp@latest"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- Update all `npx` commands in README.md to use `tech-debt-mcp@latest` instead of `tech-debt-mcp`
- Ensures users always get the latest version rather than a potentially cached one

## Changes
- VS Code one-click install URL (URL-encoded config)
- VS Code terminal command
- Cursor one-click install URL (base64-encoded config)
- Cursor terminal command
- Claude Code terminal command
- All JSON config examples (Claude Desktop, Windsurf, JetBrains, Xcode, Manual Setup)

## Related Issue
Closes #68

## Testing
- [x] All encoded URLs verified (URL-encoded and base64)
- [x] Build passes
- [x] No functional code changes

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated
- [x] Commit messages follow convention