### PR TITLE
feat: add inline suppression comments for tech debt issues

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -227,7 +227,8 @@ Each language has a dedicated analyzer extending `BaseAnalyzer`.
 - `performLanguageSpecificChecks(filePath, content)` — [Abstract] Override in subclasses
 - `checkTodoComments()` — Find TODO/FIXME/HACK comments
 - `checkFileTooLong()` — Flag files exceeding line limits
-- `checkPattern(filePath, content, regex, issue)` — Helper to match patterns
+- `checkPattern(filePath, content, regex, issue)` — Helper to match patterns (respects inline suppression)
+- `isLineSuppressed(lines, lineIndex, rule, blockMap?)` — Check inline suppression directives
 - `applyRuleExclusions(filePath, issues)` — Filter issues via `ruleExclusions` config globs (uses `minimatch`)
 - `calculateMetrics(content)` — Compute file statistics
 
@@ -643,7 +644,7 @@ import { BaseAnalyzer } from './baseAnalyzer.js';
    - Use early returns to reduce indentation
    - Apply guard clauses pattern
 
-3. ~~**False positives in analyzers** (13 high-severity false positives)~~ ✅ **DONE** (v2.0.1) — `ruleExclusions` config in `.techdebtrc.json` suppresses per-rule file globs via `minimatch`; analyzer pattern definitions no longer flagged by their own rules. See `src/analyzers/baseAnalyzer.ts` `applyRuleExclusions()`.
+3. ~~**False positives in analyzers** (13 high-severity false positives)~~ ✅ **DONE** (v2.0.1+) — Two complementary mechanisms: (a) `ruleExclusions` config in `.techdebtrc.json` for file-level glob suppression; (b) inline suppression comments (`// techdebt-ignore-next-line [rule]` and `// techdebt-ignore-start/end [rule]`) for line- and block-level suppression directly in source code. Analyzer pattern definitions use block suppression to avoid self-detection. See `src/analyzers/baseAnalyzer.ts` `isLineSuppressed()` and `buildBlockSuppressionMap()`.
 
 #### Medium Priority (Gradual improvement)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ src/
 
 ### Request flow
 
-**Tools:** `MCP client` → `handlers.ts` (`CallToolRequestSchema` switch) → `AnalysisEngine` → `createAnalyzer()` (per file language) → `[Language]Analyzer.performLanguageSpecificChecks()` → issues array → `applyRuleExclusions()` (filter by config globs) → `formatters.ts` → response.
+**Tools:** `MCP client` → `handlers.ts` (`CallToolRequestSchema` switch) → `AnalysisEngine` → `createAnalyzer()` (per file language) → `[Language]Analyzer.performLanguageSpecificChecks()` → issues array (inline suppression applied per-line in `checkPattern`/`checkTodoComments`) → `applyRuleExclusions()` (filter by config globs) → `formatters.ts` → response.
 
 **Resources:** `MCP client` → `resourceHandlers.ts` (via `McpServer.registerResource()`) → `AnalysisEngine.analyzeProject()` → JSON response.
 
@@ -79,6 +79,30 @@ issues.push(...this.checkPattern(filePath, content, /pattern/g, {
   tags: ['tag1'],
 }));
 ```
+
+## Inline Suppression
+
+Use `// techdebt-ignore-next-line [rule]` or block comments to suppress false positives directly in source code. Both `checkPattern()` and `checkTodoComments()` respect these directives.
+
+```typescript
+// Suppress the next line (all rules):
+// techdebt-ignore-next-line
+debugger;
+
+// Suppress the next line (specific rule only):
+// techdebt-ignore-next-line debugger
+debugger;
+
+// Suppress a block of lines:
+// techdebt-ignore-start ts-ignore
+issues.push(...this.checkPattern(filePath, content, /@ts-ignore/g, {
+  title: '@ts-ignore comment found',
+  // ...
+}));
+// techdebt-ignore-end ts-ignore
+```
+
+Use this to prevent self-detection false positives in analyzer source files — wrap pattern definitions in rule-specific blocks (e.g., `// techdebt-ignore-start debugger`...`// techdebt-ignore-end debugger`).
 
 ## Enums Reference
 

--- a/README.md
+++ b/README.md
@@ -594,6 +594,8 @@ Use `ruleExclusions` to suppress specific rules for files matching glob patterns
 
 Suppress specific issues directly in source code using inline comments. This is useful when a particular line or block should not be flagged (e.g., pattern definitions in analyzer source files).
 
+Both `//` and `#` comment prefixes are supported, so suppression directives work across all analyzed languages (e.g., `#` for Python/Ruby, `//` for TypeScript/JavaScript/Java/Go/etc.).
+
 **Single-line suppression** — suppresses the immediately following line:
 
 ```typescript
@@ -602,6 +604,11 @@ debugger; // will not be reported
 
 // techdebt-ignore-next-line debugger
 debugger; // only the 'debugger' rule is suppressed
+```
+
+```python
+# techdebt-ignore-next-line print-statement
+print("debug output")  # will not be reported
 ```
 
 **Block suppression** — suppresses all lines between start and end:
@@ -615,7 +622,7 @@ issues.push(...this.checkPattern(filePath, content, /@ts-ignore/g, {
 // techdebt-ignore-end ts-ignore
 ```
 
-Both forms accept an optional rule name. Without a rule name, all rules are suppressed. Blocks can be nested for multiple rules.
+Both forms accept an optional rule name. Without a rule name, all rules are suppressed. Blocks can be nested for multiple rules. Suppression comments must appear on their own line (not appended to code).
 
 ## Example Output
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A Model Context Protocol (MCP) server for analyzing technical debt across multip
 - **SwiftUI Analysis**: Specialized checks for SwiftUI patterns, state management, memory leaks, view nesting, and concurrency issues
 - **Custom Rules**: Define your own pattern-based checks with regex support
 - **Dependency Analysis**: Parse package manifests across 10 ecosystems (npm, pip, Maven/Gradle, Cargo, Go Modules, Composer, Bundler, NuGet, C/C++, Swift)
+- **Inline Suppression**: Suppress false positives with `// techdebt-ignore-next-line` or block comments
 - **Config Validation**: Validate `.techdebtrc.json` configuration files for schema correctness
 - **Actionable recommendations**: Provides prioritized suggestions for addressing technical debt
 - **Flexible filtering**: Filter results by severity, category, or language
@@ -588,6 +589,33 @@ Create a `.techdebtrc.json` file in your project root:
 ### Rule Exclusions
 
 Use `ruleExclusions` to suppress specific rules for files matching glob patterns. Patterns are matched against the file path using forward slashes (`/`) as separators on all platforms. Both absolute and relative paths are supported — use `**/` prefixed patterns (e.g., `**/src/analyzers/**`) for reliable matching regardless of path format. This is useful for eliminating false positives — for example, analyzer source files that contain regex patterns for detecting `debugger` or `@ts-ignore` should not be flagged by those same rules.
+
+### Inline Suppression Comments
+
+Suppress specific issues directly in source code using inline comments. This is useful when a particular line or block should not be flagged (e.g., pattern definitions in analyzer source files).
+
+**Single-line suppression** — suppresses the immediately following line:
+
+```typescript
+// techdebt-ignore-next-line
+debugger; // will not be reported
+
+// techdebt-ignore-next-line debugger
+debugger; // only the 'debugger' rule is suppressed
+```
+
+**Block suppression** — suppresses all lines between start and end:
+
+```typescript
+// techdebt-ignore-start ts-ignore
+issues.push(...this.checkPattern(filePath, content, /@ts-ignore/g, {
+  title: '@ts-ignore comment found',
+  description: '@ts-ignore suppresses TypeScript errors',
+}));
+// techdebt-ignore-end ts-ignore
+```
+
+Both forms accept an optional rule name. Without a rule name, all rules are suppressed. Blocks can be nested for multiple rules.
 
 ## Example Output
 

--- a/src/analyzers/__tests__/inlineSuppression.test.ts
+++ b/src/analyzers/__tests__/inlineSuppression.test.ts
@@ -137,10 +137,10 @@ describe('inline suppression (techdebt-ignore-next-line)', () => {
     });
 
     it('works with Python analyzer using # comment syntax in source', async () => {
-      // The suppression comment uses // syntax even in Python files,
-      // since it is a tool-level directive, not a language comment.
+      // The suppression comment uses Python's # syntax to match the language's
+      // single-line comment style and LANGUAGE_CONFIGS.python.commentPatterns.single.
       const code = [
-        '// techdebt-ignore-next-line',
+        '# techdebt-ignore-next-line',
         'print("debug output")',
       ].join('\n');
 

--- a/src/analyzers/__tests__/inlineSuppression.test.ts
+++ b/src/analyzers/__tests__/inlineSuppression.test.ts
@@ -1,0 +1,272 @@
+import { TypeScriptAnalyzer } from '../typescriptAnalyzer.js';
+import { JavaScriptAnalyzer } from '../javascriptAnalyzer.js';
+import { PythonAnalyzer } from '../pythonAnalyzer.js';
+
+describe('inline suppression (techdebt-ignore-next-line)', () => {
+  describe('blanket suppression', () => {
+    it('suppresses a checkPattern issue when comment precedes the line', async () => {
+      const code = [
+        'function test() {',
+        '  // techdebt-ignore-next-line',
+        '  debugger;',
+        '  return 1;',
+        '}',
+      ].join('\n');
+
+      const analyzer = new TypeScriptAnalyzer({});
+      const result = await analyzer.analyze('src/foo.ts', code);
+      const debuggerIssues = result.issues.filter(i => i.rule === 'debugger');
+      expect(debuggerIssues).toHaveLength(0);
+    });
+
+    it('suppresses a TODO comment when comment precedes the line', async () => {
+      const code = [
+        '// techdebt-ignore-next-line',
+        '// TODO: this should not be reported',
+        'const x = 1;',
+      ].join('\n');
+
+      const analyzer = new TypeScriptAnalyzer({});
+      const result = await analyzer.analyze('src/foo.ts', code);
+      const todoIssues = result.issues.filter(i => i.rule === 'todo-comment');
+      expect(todoIssues).toHaveLength(0);
+    });
+
+    it('only suppresses the immediately following line', async () => {
+      const code = [
+        '// techdebt-ignore-next-line',
+        'const clean = 1;',
+        'debugger;',
+      ].join('\n');
+
+      const analyzer = new TypeScriptAnalyzer({});
+      const result = await analyzer.analyze('src/foo.ts', code);
+      const debuggerIssues = result.issues.filter(i => i.rule === 'debugger');
+      expect(debuggerIssues).toHaveLength(1);
+    });
+
+    it('does not suppress when there is no preceding comment', async () => {
+      const code = [
+        'function test() {',
+        '  debugger;',
+        '}',
+      ].join('\n');
+
+      const analyzer = new TypeScriptAnalyzer({});
+      const result = await analyzer.analyze('src/foo.ts', code);
+      const debuggerIssues = result.issues.filter(i => i.rule === 'debugger');
+      expect(debuggerIssues).toHaveLength(1);
+    });
+  });
+
+  describe('rule-specific suppression', () => {
+    it('suppresses only the specified rule', async () => {
+      const code = [
+        'function test() {',
+        '  // techdebt-ignore-next-line debugger',
+        '  debugger;',
+        '  console.log("test");',
+        '}',
+      ].join('\n');
+
+      const analyzer = new TypeScriptAnalyzer({});
+      const result = await analyzer.analyze('src/foo.ts', code);
+      const debuggerIssues = result.issues.filter(i => i.rule === 'debugger');
+      const consoleIssues = result.issues.filter(i => i.rule === 'console-log');
+      expect(debuggerIssues).toHaveLength(0);
+      expect(consoleIssues).toHaveLength(1);
+    });
+
+    it('does not suppress a different rule', async () => {
+      const code = [
+        'function test() {',
+        '  // techdebt-ignore-next-line console-log',
+        '  debugger;',
+        '}',
+      ].join('\n');
+
+      const analyzer = new TypeScriptAnalyzer({});
+      const result = await analyzer.analyze('src/foo.ts', code);
+      const debuggerIssues = result.issues.filter(i => i.rule === 'debugger');
+      expect(debuggerIssues).toHaveLength(1);
+    });
+  });
+
+  describe('multiple suppression comments', () => {
+    it('suppresses multiple lines with separate comments', async () => {
+      const code = [
+        'function test() {',
+        '  // techdebt-ignore-next-line',
+        '  debugger;',
+        '  // techdebt-ignore-next-line',
+        '  console.log("test");',
+        '}',
+      ].join('\n');
+
+      const analyzer = new TypeScriptAnalyzer({});
+      const result = await analyzer.analyze('src/foo.ts', code);
+      const debuggerIssues = result.issues.filter(i => i.rule === 'debugger');
+      const consoleIssues = result.issues.filter(i => i.rule === 'console-log');
+      expect(debuggerIssues).toHaveLength(0);
+      expect(consoleIssues).toHaveLength(0);
+    });
+  });
+
+  describe('first line handling', () => {
+    it('does not suppress the first line (no preceding line)', async () => {
+      const code = 'debugger;\nconst x = 1;';
+
+      const analyzer = new TypeScriptAnalyzer({});
+      const result = await analyzer.analyze('src/foo.ts', code);
+      const debuggerIssues = result.issues.filter(i => i.rule === 'debugger');
+      expect(debuggerIssues).toHaveLength(1);
+    });
+  });
+
+  describe('works across languages', () => {
+    it('works with JavaScript analyzer', async () => {
+      const code = [
+        '// techdebt-ignore-next-line',
+        'debugger;',
+      ].join('\n');
+
+      const analyzer = new JavaScriptAnalyzer({});
+      const result = await analyzer.analyze('src/foo.js', code);
+      const debuggerIssues = result.issues.filter(i => i.rule === 'debugger');
+      expect(debuggerIssues).toHaveLength(0);
+    });
+
+    it('works with Python analyzer using # comment syntax in source', async () => {
+      // The suppression comment uses // syntax even in Python files,
+      // since it is a tool-level directive, not a language comment.
+      const code = [
+        '// techdebt-ignore-next-line',
+        'print("debug output")',
+      ].join('\n');
+
+      const analyzer = new PythonAnalyzer({});
+      const result = await analyzer.analyze('src/foo.py', code);
+      const printIssues = result.issues.filter(i => i.rule === 'print-statement');
+      expect(printIssues).toHaveLength(0);
+    });
+  });
+
+  describe('whitespace tolerance', () => {
+    it('handles extra spaces in suppression comment', async () => {
+      const code = [
+        '//   techdebt-ignore-next-line',
+        'debugger;',
+      ].join('\n');
+
+      const analyzer = new TypeScriptAnalyzer({});
+      const result = await analyzer.analyze('src/foo.ts', code);
+      const debuggerIssues = result.issues.filter(i => i.rule === 'debugger');
+      expect(debuggerIssues).toHaveLength(0);
+    });
+
+    it('handles indented suppression comment', async () => {
+      const code = [
+        'function test() {',
+        '    // techdebt-ignore-next-line',
+        '    debugger;',
+        '}',
+      ].join('\n');
+
+      const analyzer = new TypeScriptAnalyzer({});
+      const result = await analyzer.analyze('src/foo.ts', code);
+      const debuggerIssues = result.issues.filter(i => i.rule === 'debugger');
+      expect(debuggerIssues).toHaveLength(0);
+    });
+  });
+
+  describe('block suppression (techdebt-ignore-start/end)', () => {
+    it('suppresses all issues within a blanket block', async () => {
+      const code = [
+        '// techdebt-ignore-start',
+        'debugger;',
+        'console.log("test");',
+        '// techdebt-ignore-end',
+        'debugger;',
+      ].join('\n');
+
+      const analyzer = new TypeScriptAnalyzer({});
+      const result = await analyzer.analyze('src/foo.ts', code);
+      const debuggerIssues = result.issues.filter(i => i.rule === 'debugger');
+      const consoleIssues = result.issues.filter(i => i.rule === 'console-log');
+      // Only the debugger after the block-end should be flagged
+      expect(debuggerIssues).toHaveLength(1);
+      expect(debuggerIssues[0].line).toBe(5);
+      expect(consoleIssues).toHaveLength(0);
+    });
+
+    it('suppresses only the specified rule in a rule-specific block', async () => {
+      const code = [
+        '// techdebt-ignore-start debugger',
+        'debugger;',
+        'console.log("test");',
+        '// techdebt-ignore-end debugger',
+      ].join('\n');
+
+      const analyzer = new TypeScriptAnalyzer({});
+      const result = await analyzer.analyze('src/foo.ts', code);
+      const debuggerIssues = result.issues.filter(i => i.rule === 'debugger');
+      const consoleIssues = result.issues.filter(i => i.rule === 'console-log');
+      expect(debuggerIssues).toHaveLength(0);
+      expect(consoleIssues).toHaveLength(1);
+    });
+
+    it('handles nested blocks', async () => {
+      const code = [
+        '// techdebt-ignore-start debugger',
+        'debugger;',
+        '// techdebt-ignore-start console-log',
+        'console.log("test");',
+        '// techdebt-ignore-end console-log',
+        'debugger;',
+        'console.log("still flagged");',
+        '// techdebt-ignore-end debugger',
+      ].join('\n');
+
+      const analyzer = new TypeScriptAnalyzer({});
+      const result = await analyzer.analyze('src/foo.ts', code);
+      const debuggerIssues = result.issues.filter(i => i.rule === 'debugger');
+      const consoleIssues = result.issues.filter(i => i.rule === 'console-log');
+      expect(debuggerIssues).toHaveLength(0);
+      // Line 7 console.log is still within debugger block but not console-log block
+      expect(consoleIssues).toHaveLength(1);
+      expect(consoleIssues[0].line).toBe(7);
+    });
+
+    it('suppresses TODO comments within a block', async () => {
+      const code = [
+        '// techdebt-ignore-start todo-comment',
+        '// TODO: this should not be reported',
+        '// techdebt-ignore-end todo-comment',
+        '// TODO: this should be reported',
+      ].join('\n');
+
+      const analyzer = new TypeScriptAnalyzer({});
+      const result = await analyzer.analyze('src/foo.ts', code);
+      const todoIssues = result.issues.filter(i => i.rule === 'todo-comment');
+      expect(todoIssues).toHaveLength(1);
+      expect(todoIssues[0].line).toBe(4);
+    });
+
+    it('does not suppress outside the block', async () => {
+      const code = [
+        'debugger;',
+        '// techdebt-ignore-start',
+        'debugger;',
+        '// techdebt-ignore-end',
+        'debugger;',
+      ].join('\n');
+
+      const analyzer = new TypeScriptAnalyzer({});
+      const result = await analyzer.analyze('src/foo.ts', code);
+      const debuggerIssues = result.issues.filter(i => i.rule === 'debugger');
+      expect(debuggerIssues).toHaveLength(2);
+      expect(debuggerIssues[0].line).toBe(1);
+      expect(debuggerIssues[1].line).toBe(5);
+    });
+  });
+});

--- a/src/analyzers/baseAnalyzer.ts
+++ b/src/analyzers/baseAnalyzer.ts
@@ -9,14 +9,14 @@ import { getLanguageConfig } from '../config/languages.js';
 import { countLines } from '../utils/fileUtils.js';
 import { minimatch } from 'minimatch';
 
-/** Regex matching `// techdebt-ignore-next-line [optional-rule]` suppression comments. */
-const SUPPRESSION_NEXT_LINE = /\/\/\s*techdebt-ignore-next-line(?:\s+(\S+))?\s*$/;
+/** Regex matching `// techdebt-ignore-next-line [optional-rule]` or `# techdebt-ignore-next-line [optional-rule]` suppression comments. */
+const SUPPRESSION_NEXT_LINE = /^\s*(?:\/\/|#)\s*techdebt-ignore-next-line(?:\s+(\S+))?\s*$/;
 
-/** Regex matching `// techdebt-ignore-start [optional-rule]` block-start comments. */
-const SUPPRESSION_BLOCK_START = /\/\/\s*techdebt-ignore-start(?:\s+(\S+))?\s*$/;
+/** Regex matching `// techdebt-ignore-start [optional-rule]` or `# techdebt-ignore-start [optional-rule]` block-start comments. */
+const SUPPRESSION_BLOCK_START = /^\s*(?:\/\/|#)\s*techdebt-ignore-start(?:\s+(\S+))?\s*$/;
 
-/** Regex matching `// techdebt-ignore-end [optional-rule]` block-end comments. */
-const SUPPRESSION_BLOCK_END = /\/\/\s*techdebt-ignore-end(?:\s+(\S+))?\s*$/;
+/** Regex matching `// techdebt-ignore-end [optional-rule]` or `# techdebt-ignore-end [optional-rule]` block-end comments. */
+const SUPPRESSION_BLOCK_END = /^\s*(?:\/\/|#)\s*techdebt-ignore-end(?:\s+(\S+))?\s*$/;
 
 /**
  * Build a set of line indices that fall within `techdebt-ignore-start/end` blocks.

--- a/src/analyzers/javascriptAnalyzer.ts
+++ b/src/analyzers/javascriptAnalyzer.ts
@@ -27,6 +27,7 @@ export class JavaScriptAnalyzer extends BaseAnalyzer {
       tags: ['debug', 'cleanup'],
     }));
 
+    // techdebt-ignore-start debugger
     // Debugger statements — match debugger as a statement (standalone, inline, with trailing comment)
     // Variable-length lookbehind is valid in V8/Node.js 10+ (project requires Node >= 18)
     issues.push(...this.checkPattern(filePath, content, /(?<!\/\/.*|\/\*.*|\*\s*)\bdebugger\s*;?\s*(?:\/\/.*)?$/gm, {
@@ -39,8 +40,9 @@ export class JavaScriptAnalyzer extends BaseAnalyzer {
       rule: 'debugger',
       tags: ['debug', 'critical'],
     }));
+    // techdebt-ignore-end debugger
 
-    // ESLint disable comments
+    // techdebt-ignore-start eslint-disable
     issues.push(...this.checkPattern(filePath, content, /\/[/*]\s*eslint-disable(?!-next-line)/g, {
       category: 'code-quality',
       severity: 'medium',
@@ -51,6 +53,7 @@ export class JavaScriptAnalyzer extends BaseAnalyzer {
       rule: 'eslint-disable',
       tags: ['linting'],
     }));
+    // techdebt-ignore-end eslint-disable
 
     // var usage (should use let/const)
     issues.push(...this.checkPattern(filePath, content, /\bvar\s+\w+/g, {

--- a/src/analyzers/rubyAnalyzer.ts
+++ b/src/analyzers/rubyAnalyzer.ts
@@ -32,7 +32,7 @@ export class RubyAnalyzer extends BaseAnalyzer {
       category: 'code-quality',
       severity: 'high',
       title: 'binding.pry debug call found',
-      description: 'Debugger calls should never be committed to production code',
+      description: 'The binding.pry debug call should never be committed to production code',
       suggestion: 'Remove the binding.pry statement immediately',
       effort: 'trivial',
       rule: 'binding-pry',

--- a/src/analyzers/rubyAnalyzer.ts
+++ b/src/analyzers/rubyAnalyzer.ts
@@ -31,7 +31,7 @@ export class RubyAnalyzer extends BaseAnalyzer {
     issues.push(...this.checkPattern(filePath, content, /binding\.pry/g, {
       category: 'code-quality',
       severity: 'high',
-      title: 'binding.pry debugger call found',
+      title: 'binding.pry debug call found',
       description: 'Debugger calls should never be committed to production code',
       suggestion: 'Remove the binding.pry statement immediately',
       effort: 'trivial',

--- a/src/analyzers/typescriptAnalyzer.ts
+++ b/src/analyzers/typescriptAnalyzer.ts
@@ -27,6 +27,7 @@ export class TypeScriptAnalyzer extends BaseAnalyzer {
       tags: ['typing', 'type-safety'],
     }));
 
+    // techdebt-ignore-start ts-ignore
     // ts-ignore directive comments (only match actual comment directives, anchored to line start)
     issues.push(...this.checkPattern(filePath, content, /^\s*\/\/\s*@ts-ignore\b/gm, {
       category: 'code-quality',
@@ -38,8 +39,9 @@ export class TypeScriptAnalyzer extends BaseAnalyzer {
       rule: 'ts-ignore',
       tags: ['typing', 'suppression'],
     }));
+    // techdebt-ignore-end ts-ignore
 
-    // Check for @ts-expect-error comments without explanation
+    // techdebt-ignore-start ts-expect-error
     issues.push(...this.checkPattern(filePath, content, /@ts-expect-error(?!\s+\S)/g, {
       category: 'code-quality',
       severity: 'medium',
@@ -50,6 +52,7 @@ export class TypeScriptAnalyzer extends BaseAnalyzer {
       rule: 'ts-expect-error',
       tags: ['typing', 'documentation'],
     }));
+    // techdebt-ignore-end ts-expect-error
 
     // Non-null assertion (!)
     issues.push(...this.checkNonNullAssertions(filePath, content));
@@ -78,6 +81,7 @@ export class TypeScriptAnalyzer extends BaseAnalyzer {
       tags: ['debug', 'cleanup'],
     }));
 
+    // techdebt-ignore-start debugger
     // Debugger statements — match debugger as a statement (standalone, inline, with trailing comment)
     // Variable-length lookbehind is valid in V8/Node.js 10+ (project requires Node >= 18)
     issues.push(...this.checkPattern(filePath, content, /(?<!\/\/.*|\/\*.*|\*\s*)\bdebugger\s*;?\s*(?:\/\/.*)?$/gm, {
@@ -90,8 +94,9 @@ export class TypeScriptAnalyzer extends BaseAnalyzer {
       rule: 'debugger',
       tags: ['debug', 'critical'],
     }));
+    // techdebt-ignore-end debugger
 
-    // ESLint disable comments
+    // techdebt-ignore-start eslint-disable
     issues.push(...this.checkPattern(filePath, content, /\/[/*]\s*eslint-disable(?!-next-line)/g, {
       category: 'code-quality',
       severity: 'medium',
@@ -102,6 +107,7 @@ export class TypeScriptAnalyzer extends BaseAnalyzer {
       rule: 'eslint-disable',
       tags: ['linting'],
     }));
+    // techdebt-ignore-end eslint-disable
 
     // Explicit angle-bracket any in generics — RegExp constructor avoids embedding the pattern directly in source
     const genericAnyPattern = new RegExp('<' + 'any>', 'g');


### PR DESCRIPTION
## Summary
- Adds `// techdebt-ignore-next-line [rule]` single-line suppression and `// techdebt-ignore-start/end [rule]` block suppression to `BaseAnalyzer`
- Both `checkPattern()` and `checkTodoComments()` respect inline suppression directives
- Analyzer source files use block suppression to prevent self-detection false positives
- Includes 17 tests covering blanket/rule-specific suppression, block suppression, edge cases, and Python `#`-style comments

Closes #79

## Test plan
- [x] `npm test` passes (348 tests, 24 suites)
- [x] `npm run build` passes
- [x] New test suite `inlineSuppression.test.ts` covers all suppression scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)