### PR TITLE
fix: replace <any> generics and suppress non-null-assertion false positives

### DIFF
--- a/src/analyzers/__tests__/inlineSuppression.test.ts
+++ b/src/analyzers/__tests__/inlineSuppression.test.ts
@@ -269,4 +269,58 @@ describe('inline suppression (techdebt-ignore-next-line)', () => {
       expect(debuggerIssues[1].line).toBe(5);
     });
   });
+
+  describe('non-null-assertion block suppression (checkNonNullAssertions bespoke path)', () => {
+    it('suppresses non-null assertions within a rule-specific block', async () => {
+      const code = [
+        'const a = foo!.bar;',
+        '// techdebt-ignore-start non-null-assertion',
+        'const b = foo!.bar;',
+        'const c = baz!.qux;',
+        '// techdebt-ignore-end non-null-assertion',
+        'const d = foo!.bar;',
+      ].join('\n');
+
+      const analyzer = new TypeScriptAnalyzer({});
+      const result = await analyzer.analyze('src/foo.ts', code);
+      const nonNullIssues = result.issues.filter(i => i.rule === 'non-null-assertion');
+      // Lines 1 and 6 are outside the block — both should be reported
+      expect(nonNullIssues).toHaveLength(2);
+      expect(nonNullIssues[0].line).toBe(1);
+      expect(nonNullIssues[1].line).toBe(6);
+    });
+
+    it('suppresses all non-null assertions within a blanket block', async () => {
+      const code = [
+        '// techdebt-ignore-start',
+        'const x = foo!.bar;',
+        'const y = baz!.qux;',
+        '// techdebt-ignore-end',
+        'const z = foo!.bar;',
+      ].join('\n');
+
+      const analyzer = new TypeScriptAnalyzer({});
+      const result = await analyzer.analyze('src/foo.ts', code);
+      const nonNullIssues = result.issues.filter(i => i.rule === 'non-null-assertion');
+      // Only line 5 is outside the block
+      expect(nonNullIssues).toHaveLength(1);
+      expect(nonNullIssues[0].line).toBe(5);
+    });
+
+    it('does not suppress non-null assertions outside the block', async () => {
+      const code = [
+        'const a = foo!.bar;',
+        '// techdebt-ignore-start non-null-assertion',
+        '// techdebt-ignore-end non-null-assertion',
+        'const b = baz!.qux;',
+      ].join('\n');
+
+      const analyzer = new TypeScriptAnalyzer({});
+      const result = await analyzer.analyze('src/foo.ts', code);
+      const nonNullIssues = result.issues.filter(i => i.rule === 'non-null-assertion');
+      expect(nonNullIssues).toHaveLength(2);
+      expect(nonNullIssues[0].line).toBe(1);
+      expect(nonNullIssues[1].line).toBe(4);
+    });
+  });
 });

--- a/src/analyzers/baseAnalyzer.ts
+++ b/src/analyzers/baseAnalyzer.ts
@@ -23,7 +23,7 @@ const SUPPRESSION_BLOCK_END = /^\s*(?:\/\/|#)\s*techdebt-ignore-end(?:\s+(\S+))?
  * Supports rule-specific blocks: only lines for the matching rule are suppressed.
  * Returns a Map from line index to the set of suppressed rules (empty string = all).
  */
-function buildBlockSuppressionMap(lines: string[]): Map<number, Set<string>> {
+export function buildBlockSuppressionMap(lines: string[]): Map<number, Set<string>> {
   const map = new Map<number, Set<string>>();
   const openBlocks: string[] = []; // stack of rule names ("" = blanket)
 

--- a/src/analyzers/rustAnalyzer.ts
+++ b/src/analyzers/rustAnalyzer.ts
@@ -76,6 +76,7 @@ export class RustAnalyzer extends BaseAnalyzer {
     }));
 
     // techdebt-ignore-start non-null-assertion
+    // Suppress TS non-null assertion false positives: Rust macros (panic!, println!, dbg!, etc.) contain '!' but are not TS non-null assertions
     // panic! macro
     issues.push(...this.checkPattern(filePath, content, /panic!\s*\(/g, {
       category: 'code-quality',

--- a/src/analyzers/rustAnalyzer.ts
+++ b/src/analyzers/rustAnalyzer.ts
@@ -75,6 +75,7 @@ export class RustAnalyzer extends BaseAnalyzer {
       tags: ['warnings', 'quality'],
     }));
 
+    // techdebt-ignore-start non-null-assertion
     // panic! macro
     issues.push(...this.checkPattern(filePath, content, /panic!\s*\(/g, {
       category: 'code-quality',
@@ -134,6 +135,7 @@ export class RustAnalyzer extends BaseAnalyzer {
       rule: 'unimplemented-macro',
       tags: ['incomplete-code', 'reliability'],
     }));
+    // techdebt-ignore-end non-null-assertion
 
     return issues;
   }

--- a/src/analyzers/swiftAnalyzer.ts
+++ b/src/analyzers/swiftAnalyzer.ts
@@ -18,6 +18,7 @@ export class SwiftAnalyzer extends BaseAnalyzer {
     // Force unwrap (!)
     issues.push(...this.checkForceUnwrap(filePath, content));
 
+    // techdebt-ignore-start non-null-assertion
     // Force cast (as!)
     issues.push(...this.checkPattern(filePath, content, /\bas!\s*\w+/g, {
       category: 'code-quality',
@@ -41,6 +42,7 @@ export class SwiftAnalyzer extends BaseAnalyzer {
       rule: 'force-try',
       tags: ['safety', 'crash-risk', 'error-handling'],
     }));
+    // techdebt-ignore-end non-null-assertion
 
     // Implicitly unwrapped optionals
     issues.push(...this.checkImplicitlyUnwrapped(filePath, content));
@@ -152,7 +154,9 @@ export class SwiftAnalyzer extends BaseAnalyzer {
       // Match force unwrap but exclude != and !== and comments
       if (line.trim().startsWith('//')) continue;
 
+      // techdebt-ignore-start non-null-assertion
       // Match patterns like variable! or expression! but not as! or try!
+      // techdebt-ignore-end non-null-assertion
       const matches = line.match(/\w+!(?:\.|[\s,);}\]]|$)/g);
       if (matches) {
         // Filter out common false positives

--- a/src/analyzers/swiftAnalyzer.ts
+++ b/src/analyzers/swiftAnalyzer.ts
@@ -19,6 +19,7 @@ export class SwiftAnalyzer extends BaseAnalyzer {
     issues.push(...this.checkForceUnwrap(filePath, content));
 
     // techdebt-ignore-start non-null-assertion
+    // Suppress TS non-null assertion false positives: Swift syntax (as!, try!) contains '!' but is not a TS non-null assertion
     // Force cast (as!)
     issues.push(...this.checkPattern(filePath, content, /\bas!\s*\w+/g, {
       category: 'code-quality',

--- a/src/analyzers/typescriptAnalyzer.ts
+++ b/src/analyzers/typescriptAnalyzer.ts
@@ -1,5 +1,5 @@
 import { TechDebtIssue, TechDebtConfig } from '../types/index.js';
-import { BaseAnalyzer } from './baseAnalyzer.js';
+import { BaseAnalyzer, buildBlockSuppressionMap } from './baseAnalyzer.js';
 
 /**
  * TypeScript-specific analyzer
@@ -128,8 +128,12 @@ export class TypeScriptAnalyzer extends BaseAnalyzer {
   private checkNonNullAssertions(filePath: string, content: string): TechDebtIssue[] {
     const issues: TechDebtIssue[] = [];
     const lines = content.split('\n');
+    const blockMap = buildBlockSuppressionMap(lines);
 
     for (let i = 0; i < lines.length; i++) {
+      if (this.isLineSuppressed(lines, i, 'non-null-assertion', blockMap)) {
+        continue;
+      }
       const line = lines[i];
       // Match non-null assertions but exclude !== and !=
       const matches = line.match(/\w+!(?:\.|\[|;|,|\)|\s|$)/g);

--- a/src/server/__tests__/dependencyHandlers.test.ts
+++ b/src/server/__tests__/dependencyHandlers.test.ts
@@ -1,4 +1,5 @@
 import { jest } from '@jest/globals';
+import type { ParsedDependency } from '../../types/index.js';
 
 jest.mock('../../utils/fileUtils.js', () => ({
   fileExists: jest.fn(),
@@ -36,7 +37,7 @@ function makeMockParser(
   ecosystem = 'npm'
 ) {
   return {
-    parse: jest.fn<any>().mockResolvedValue(deps),
+    parse: jest.fn<() => Promise<ParsedDependency[]>>().mockResolvedValue(deps),
     getEcosystem: jest.fn().mockReturnValue(ecosystem),
     canParse: jest.fn().mockReturnValue(true),
     getPackageFileNames: jest.fn().mockReturnValue(['package.json']),
@@ -139,7 +140,7 @@ describe('handleCheckDependencies', () => {
     mockStat.mockResolvedValueOnce({ isDirectory: () => false, isFile: () => true } as any);
 
     const parser = {
-      parse: jest.fn<any>().mockRejectedValue(new Error('Malformed JSON')),
+      parse: jest.fn<() => Promise<ParsedDependency[]>>().mockRejectedValue(new Error('Malformed JSON')),
       getEcosystem: jest.fn().mockReturnValue('npm'),
       canParse: jest.fn().mockReturnValue(true),
       getPackageFileNames: jest.fn().mockReturnValue(['package.json']),
@@ -285,7 +286,7 @@ describe('handleGetVulnerabilityReport', () => {
     mockStat.mockResolvedValueOnce({ isDirectory: () => false, isFile: () => true } as any);
 
     const parser = {
-      parse: jest.fn<any>().mockRejectedValue(new Error('Unexpected token')),
+      parse: jest.fn<() => Promise<ParsedDependency[]>>().mockRejectedValue(new Error('Unexpected token')),
       getEcosystem: jest.fn().mockReturnValue('npm'),
       canParse: jest.fn().mockReturnValue(true),
       getPackageFileNames: jest.fn().mockReturnValue(['package.json']),

--- a/src/server/__tests__/dependencyHandlers.test.ts
+++ b/src/server/__tests__/dependencyHandlers.test.ts
@@ -33,7 +33,7 @@ const mockStat = stat as jest.MockedFunction<typeof stat>;
 
 /** Helper to build a mock parser instance. */
 function makeMockParser(
-  deps: Array<{ name: string; version: string; isDev: boolean; source: string }>,
+  deps: ParsedDependency[],
   ecosystem = 'npm'
 ) {
   return {

--- a/src/server/__tests__/dependencyHandlers.test.ts
+++ b/src/server/__tests__/dependencyHandlers.test.ts
@@ -37,7 +37,7 @@ function makeMockParser(
   ecosystem = 'npm'
 ) {
   return {
-    parse: jest.fn<() => Promise<ParsedDependency[]>>().mockResolvedValue(deps),
+    parse: jest.fn<(filePath: string, content: string) => Promise<ParsedDependency[]>>().mockResolvedValue(deps),
     getEcosystem: jest.fn().mockReturnValue(ecosystem),
     canParse: jest.fn().mockReturnValue(true),
     getPackageFileNames: jest.fn().mockReturnValue(['package.json']),
@@ -140,7 +140,7 @@ describe('handleCheckDependencies', () => {
     mockStat.mockResolvedValueOnce({ isDirectory: () => false, isFile: () => true } as any);
 
     const parser = {
-      parse: jest.fn<() => Promise<ParsedDependency[]>>().mockRejectedValue(new Error('Malformed JSON')),
+      parse: jest.fn<(filePath: string, content: string) => Promise<ParsedDependency[]>>().mockRejectedValue(new Error('Malformed JSON')),
       getEcosystem: jest.fn().mockReturnValue('npm'),
       canParse: jest.fn().mockReturnValue(true),
       getPackageFileNames: jest.fn().mockReturnValue(['package.json']),
@@ -286,7 +286,7 @@ describe('handleGetVulnerabilityReport', () => {
     mockStat.mockResolvedValueOnce({ isDirectory: () => false, isFile: () => true } as any);
 
     const parser = {
-      parse: jest.fn<() => Promise<ParsedDependency[]>>().mockRejectedValue(new Error('Unexpected token')),
+      parse: jest.fn<(filePath: string, content: string) => Promise<ParsedDependency[]>>().mockRejectedValue(new Error('Unexpected token')),
       getEcosystem: jest.fn().mockReturnValue('npm'),
       canParse: jest.fn().mockReturnValue(true),
       getPackageFileNames: jest.fn().mockReturnValue(['package.json']),


### PR DESCRIPTION
## Summary
- Replace `jest.fn<any>()` with `jest.fn<() => Promise<ParsedDependency[]>>()` in `dependencyHandlers.test.ts` to eliminate the two `<any>` generic usages flagged by the TypeScript analyzer
- Add `techdebt-ignore-start/end non-null-assertion` suppression blocks in `rustAnalyzer.ts` around Rust macro string literals (`panic!`, `println!`, `dbg!`, `todo!`, `unimplemented!`) to prevent the TypeScript analyzer from falsely flagging these string contents as non-null assertions
- Add `techdebt-ignore-start/end non-null-assertion` suppression blocks in `swiftAnalyzer.ts` around force-cast (`as!`) and force-try (`try!`) title/description string literals for the same reason

The `<any>` instances in `analysisEngine.ts` were already gone (previously fixed). The non-null assertion instances in `rustAnalyzer.ts` and `swiftAnalyzer.ts` were all false positives — the `!` characters appear inside string literals that document Rust/Swift language constructs, not as TypeScript non-null assertion operators.

Closes #81

## Test plan
- [x] `npm test` passes (421 tests, 0 failures)
- [x] `npm run build` passes (no TypeScript errors)
- [ ] Verify the tool no longer self-reports these false positives when run on the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)