### PR TITLE
docs: add doc-consistency review instructions to copilot-instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -78,7 +78,7 @@ Copilot **must** check documentation consistency on every PR. **Do not approve**
 - A new analyzer or dependency parser is added but not reflected in the architecture docs
 - A phase issue is closed but `ROADMAP.md` still shows it as pending
 - A public API signature changes but JSDoc or README examples are stale
-- `CHANGELOG.md` is missing an entry when `package.json` version is bumped or a `vX.X.X` Git tag is introduced
+- `CHANGELOG.md` is missing an entry when `package.json` version is bumped (the only detectable release signal in a PR diff; Git tags are not part of the changeset and cannot be checked here)
 
 ### Review Steps
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -56,6 +56,37 @@ src/
 ❌ Skipped: [why suggestion doesn't apply]
 ```
 
+## Documentation Consistency Review
+
+Copilot **must** check documentation consistency on every PR. **Do not approve** any PR where documentation is inconsistent with the code changes.
+
+### Doc Files to Check
+
+| File | What to verify |
+|------|----------------|
+| `README.md` | Features list, tool/resource docs, usage examples |
+| `ARCHITECTURE.md` | Project structure, component descriptions, data flow diagrams |
+| `ROADMAP.md` | Phase status, current status section |
+| `CHANGELOG.md` | Version entries for release-tagged changes |
+| `CLAUDE.md` | Architecture tree, request flow, recipes, conventions |
+| `.github/copilot-instructions.md` | Architecture diagram if high-level structure changed |
+
+### Inconsistency Triggers (Block Approval)
+
+- A new MCP tool is added but not listed in `README.md` or `CLAUDE.md`
+- A file is added, removed, or renamed but the architecture tree in `CLAUDE.md` or `ARCHITECTURE.md` is not updated
+- A new analyzer or dependency parser is added but not reflected in the architecture docs
+- A phase issue is closed but `ROADMAP.md` still shows it as pending
+- A public API signature changes but JSDoc or README examples are stale
+- `CHANGELOG.md` is missing an entry for a release-tagged change
+
+### Review Steps
+
+1. Scan which source files were modified in the PR diff
+2. Cross-check the relevant doc files above for stale references, missing entries, or outdated descriptions
+3. Leave a review comment listing **each inconsistency found** (file, line or section, description of the problem)
+4. **Withhold approval** until all doc inconsistencies are resolved
+
 ## Git Workflow
 
 - **Branch from `develop`**, never commit to `master` directly

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -39,7 +39,7 @@ src/
 
 1. Run `npm test` — all tests must pass
 2. Run `npm run build` — no TypeScript errors
-3. Update relevant docs (README.md, ROADMAP.md, CHANGELOG.md, CLAUDE.md)
+3. Update relevant docs (README.md, ROADMAP.md, CHANGELOG.md, CLAUDE.md, ARCHITECTURE.md, `.github/copilot-instructions.md`) — see [Doc Files to Check](#doc-files-to-check) for the full list
 
 ### After PR is Created
 
@@ -67,7 +67,7 @@ Copilot **must** check documentation consistency on every PR. **Do not approve**
 | `README.md` | Features list, tool/resource docs, usage examples |
 | `ARCHITECTURE.md` | Project structure, component descriptions, data flow diagrams |
 | `ROADMAP.md` | Phase status, current status section |
-| `CHANGELOG.md` | Version entries for release-tagged changes |
+| `CHANGELOG.md` | Version entries when `package.json` version is bumped or a `vX.X.X` tag is present |
 | `CLAUDE.md` | Architecture tree, request flow, recipes, conventions |
 | `.github/copilot-instructions.md` | Architecture diagram if high-level structure changed |
 
@@ -78,7 +78,7 @@ Copilot **must** check documentation consistency on every PR. **Do not approve**
 - A new analyzer or dependency parser is added but not reflected in the architecture docs
 - A phase issue is closed but `ROADMAP.md` still shows it as pending
 - A public API signature changes but JSDoc or README examples are stale
-- `CHANGELOG.md` is missing an entry for a release-tagged change
+- `CHANGELOG.md` is missing an entry when `package.json` version is bumped or a `vX.X.X` Git tag is introduced
 
 ### Review Steps
 


### PR DESCRIPTION
## Summary
- Added a new **Documentation Consistency Review** section to `.github/copilot-instructions.md`
- Instructs Copilot to withhold PR approval when any of the six doc files (`README.md`, `ARCHITECTURE.md`, `ROADMAP.md`, `CHANGELOG.md`, `CLAUDE.md`, `.github/copilot-instructions.md`) are inconsistent with code changes
- Lists specific inconsistency triggers that block approval (new tools not in README, architecture tree not updated, stale ROADMAP phase status, missing CHANGELOG entries, etc.)
- Provides concrete four-step review process for Copilot to follow

Closes #114

## Test plan
- [x] `npm test` passes (421 tests, 25 suites)
- [x] `npm run build` passes (no TypeScript errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)