### PR TITLE
refactor: reduce nesting in core engines (analysisEngine, customRulesEngine)

### DIFF
--- a/src/core/analysisEngine.ts
+++ b/src/core/analysisEngine.ts
@@ -80,37 +80,13 @@ export class AnalysisEngine {
 
     for (const file of filesToAnalyze) {
       const lang = detectLanguageFromExtension(file);
-      if (!lang || !targetLanguages.has(lang)) {
-        continue;
-      }
+      if (!lang || !targetLanguages.has(lang)) continue;
 
-      try {
-        const result = await analyzeFile(file, mergedConfig);
+      const fileIssues = await this.analyzeFileSafe(file, projectPath, mergedConfig, options);
+      if (fileIssues === null) continue;
 
-        // Convert absolute paths to relative
-        const relativePath = getRelativePath(projectPath, file);
-        const issues = result.issues.map(issue => ({
-          ...issue,
-          file: relativePath,
-        }));
-
-        // Filter by severity if specified
-        const { severity, categories } = options;
-        const filteredIssues = severity
-          ? issues.filter(i => this.severityMeetsThreshold(i.severity, severity))
-          : issues;
-
-        // Filter by categories if specified
-        const categoryFiltered = categories
-          ? filteredIssues.filter(i => categories.includes(i.category))
-          : filteredIssues;
-
-        allIssues.push(...categoryFiltered);
-        analyzedCount++;
-      } catch {
-        // Skip files that cannot be analyzed (e.g., encoding or permission errors).
-        // Individual file failures should not abort the whole project scan.
-      }
+      allIssues.push(...fileIssues);
+      analyzedCount++;
     }
 
     // Find package files
@@ -145,6 +121,40 @@ export class AnalysisEngine {
       issues: allIssues,
       recommendations,
     };
+  }
+
+  /**
+   * Analyze a single file, returning filtered issues or null on failure
+   */
+  private async analyzeFileSafe(
+    file: string,
+    projectPath: string,
+    config: TechDebtConfig,
+    options: AnalysisOptions
+  ): Promise<TechDebtIssue[] | null> {
+    try {
+      const result = await analyzeFile(file, config);
+      const relativePath = getRelativePath(projectPath, file);
+      const issues = result.issues.map(issue => ({ ...issue, file: relativePath }));
+      return this.filterIssues(issues, options);
+    } catch {
+      // Skip files that cannot be analyzed (e.g., encoding or permission errors).
+      // Individual file failures should not abort the whole project scan.
+      return null;
+    }
+  }
+
+  /**
+   * Apply severity and category filters to a list of issues
+   */
+  private filterIssues(issues: TechDebtIssue[], options: AnalysisOptions): TechDebtIssue[] {
+    const { severity, categories } = options;
+    const bySeverity = severity
+      ? issues.filter(i => this.severityMeetsThreshold(i.severity, severity))
+      : issues;
+    return categories
+      ? bySeverity.filter(i => categories.includes(i.category))
+      : bySeverity;
   }
 
   /**

--- a/src/core/customRulesEngine.ts
+++ b/src/core/customRulesEngine.ts
@@ -108,68 +108,88 @@ export class CustomRulesEngine {
     content: string,
     pattern: CustomPattern
   ): TechDebtIssue[] {
-    const issues: TechDebtIssue[] = [];
-
     try {
-      // Normalize line endings for cross-platform consistency
       const lines = content.split(/\r?\n/);
-      const flags = pattern.flags || 'g';
-      const regex = new RegExp(pattern.pattern, flags);
-
-      for (let lineNum = 0; lineNum < lines.length; lineNum++) {
-        const line = lines[lineNum];
-        let matchIndex = 0;
-
-        // Handle multiple matches on the same line
-        if (regex.global) {
-          let match;
-          regex.lastIndex = 0;
-          while ((match = regex.exec(line)) !== null) {
-            issues.push({
-              id: `${pattern.id}-${lineNum + 1}-${matchIndex}`,
-              category: pattern.category,
-              severity: pattern.severity,
-              file: filePath,
-              line: lineNum + 1,
-              column: match.index,
-              title: pattern.message,
-              description: line.trim(),
-              suggestion: pattern.suggestion || `Review and fix according to rule: ${pattern.id}`,
-              effort: 'small',
-              rule: pattern.id,
-              tags: [pattern.id, 'custom-rule'],
-            });
-            matchIndex++;
-          }
-        } else {
-          // Non-global flag: match once per line
-          regex.lastIndex = 0;
-          const match = regex.exec(line);
-          if (match) {
-            issues.push({
-              id: `${pattern.id}-${lineNum + 1}`,
-              category: pattern.category,
-              severity: pattern.severity,
-              file: filePath,
-              line: lineNum + 1,
-              column: match.index,
-              title: pattern.message,
-              description: line.trim(),
-              suggestion: pattern.suggestion || `Review and fix according to rule: ${pattern.id}`,
-              effort: 'small',
-              rule: pattern.id,
-              tags: [pattern.id, 'custom-rule'],
-            });
-          }
-        }
-      }
+      const regex = new RegExp(pattern.pattern, pattern.flags || 'g');
+      return lines.flatMap((line, index) =>
+        this.matchLineIssues(filePath, line, index + 1, regex, pattern)
+      );
     } catch (error) {
       if (this.onRuleError) {
         this.onRuleError(pattern.id, error instanceof Error ? error : new Error(String(error)));
       }
+      return [];
+    }
+  }
+
+  /**
+   * Match all issues on a single line for a given pattern
+   */
+  private matchLineIssues(
+    filePath: string,
+    line: string,
+    lineNum: number,
+    regex: RegExp,
+    pattern: CustomPattern
+  ): TechDebtIssue[] {
+    if (!regex.global) {
+      return this.matchSingleIssue(filePath, line, lineNum, regex, pattern);
+    }
+
+    const issues: TechDebtIssue[] = [];
+    let matchIndex = 0;
+    let match: RegExpExecArray | null;
+    regex.lastIndex = 0;
+
+    while ((match = regex.exec(line)) !== null) {
+      issues.push(this.buildIssue(filePath, line, lineNum, match.index, `${lineNum}-${matchIndex}`, pattern));
+      matchIndex++;
     }
 
     return issues;
+  }
+
+  /**
+   * Match at most one issue on a line for a non-global regex
+   */
+  private matchSingleIssue(
+    filePath: string,
+    line: string,
+    lineNum: number,
+    regex: RegExp,
+    pattern: CustomPattern
+  ): TechDebtIssue[] {
+    regex.lastIndex = 0;
+    const match = regex.exec(line);
+    if (!match) return [];
+    return [this.buildIssue(filePath, line, lineNum, match.index, `${lineNum}`, pattern)];
+  }
+
+  /**
+   * Build a TechDebtIssue from a regex match
+   */
+  private buildIssue(
+    filePath: string,
+    line: string,
+    lineNum: number,
+    column: number,
+    idSuffix: string,
+    pattern: CustomPattern
+  ): TechDebtIssue {
+    return {
+      id: `${pattern.id}-${idSuffix}`,
+      category: pattern.category,
+      severity: pattern.severity,
+      file: filePath,
+      line: lineNum,
+      column,
+      title: pattern.message,
+      description: line.trim(),
+      suggestion: pattern.suggestion || `Review and fix according to rule: ${pattern.id}`,
+      effort: 'small',
+      rule: pattern.id,
+      tags: [pattern.id, 'custom-rule'],
+    };
   }
 
   /**


### PR DESCRIPTION
## Summary
- Extracted file analysis and issue-filtering logic from `analyzeProject()` into two private helpers (`analyzeFileSafe`, `filterIssues`), reducing the hot-path nesting in `analysisEngine.ts` from 5 to ≤4 levels.
- Split the deeply-nested `executePattern()` method in `customRulesEngine.ts` (depth 7) into three focused helpers: `matchLineIssues`, `matchSingleIssue`, and `buildIssue`, each ≤4 levels deep.
- No behaviour changes — all 458 tests pass, build is clean.

Closes #86

## Test plan
- [x] `npm test` passes (458 passed, 21 todo)
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)