### PR TITLE
refactor: reduce nesting in server modules to ≤4 levels

### DIFF
--- a/src/server/configValidator.ts
+++ b/src/server/configValidator.ts
@@ -28,6 +28,112 @@ const VALID_RULE_KEYS = new Set(['maxFileLines', 'maxFunctionLines', 'maxComplex
 const VALID_SEVERITIES = new Set(['low', 'medium', 'high', 'critical']);
 
 /**
+ * Validate that a config field is an array of strings.
+ */
+function validateStringArrayField(
+  key: string,
+  config: Record<string, unknown>,
+  errors: string[],
+): void {
+  if (!(key in config)) return;
+  const value = config[key];
+  if (!Array.isArray(value)) {
+    errors.push(`"${key}" must be an array of glob strings`);
+    return;
+  }
+  if (value.some((v: unknown) => typeof v !== 'string')) {
+    errors.push(`"${key}" array must contain only strings`);
+  }
+}
+
+/**
+ * Validate the "rules" field of the config.
+ */
+function validateRulesField(
+  config: Record<string, unknown>,
+  errors: string[],
+  warnings: string[],
+): void {
+  if (!('rules' in config)) return;
+  if (!isRecord(config.rules)) {
+    errors.push('"rules" must be an object');
+    return;
+  }
+  const rules = config.rules;
+  for (const key of Object.keys(rules)) {
+    if (!VALID_RULE_KEYS.has(key)) warnings.push(`Unknown rule key: "${key}"`);
+  }
+  for (const key of VALID_RULE_KEYS) {
+    if (key in rules && typeof rules[key] !== 'number') {
+      errors.push(`"rules.${key}" must be a number`);
+    }
+  }
+}
+
+/**
+ * Validate the "severity" field of the config.
+ */
+function validateSeverityField(config: Record<string, unknown>, errors: string[]): void {
+  if (!('severity' in config)) return;
+  if (!isRecord(config.severity)) {
+    errors.push('"severity" must be an object');
+    return;
+  }
+  for (const [rule, level] of Object.entries(config.severity)) {
+    if (typeof level !== 'string' || !VALID_SEVERITIES.has(level)) {
+      errors.push(`"severity.${rule}" has invalid value "${level}" — must be a string: low, medium, high, critical`);
+    }
+  }
+}
+
+/**
+ * Validate the "ruleExclusions" field of the config.
+ */
+function validateRuleExclusionsField(config: Record<string, unknown>, errors: string[]): void {
+  if (!('ruleExclusions' in config)) return;
+  if (!isRecord(config.ruleExclusions)) {
+    errors.push('"ruleExclusions" must be an object mapping rule names to arrays of glob strings');
+    return;
+  }
+  for (const [rule, patterns] of Object.entries(config.ruleExclusions)) {
+    if (!Array.isArray(patterns)) {
+      errors.push(`"ruleExclusions.${rule}" must be an array of glob strings`);
+    } else if (patterns.some((v: unknown) => typeof v !== 'string')) {
+      errors.push(`"ruleExclusions.${rule}" array must contain only strings`);
+    }
+  }
+}
+
+/**
+ * Validate a single custom pattern entry and push any errors.
+ */
+function validateCustomPattern(p: unknown, i: number, errors: string[]): void {
+  if (!isRecord(p)) {
+    errors.push(`customPatterns[${i}]: must be an object`);
+    return;
+  }
+  if (!isCustomPatternShape(p)) {
+    errors.push(`customPatterns[${i}]: missing required fields (id, pattern, severity, category, message)`);
+    return;
+  }
+  const result = CustomRulesEngine.validatePattern(p);
+  if (!result.valid) {
+    result.errors.forEach(e => errors.push(`customPatterns[${i}] (${p.id}): ${e}`));
+  }
+}
+
+/**
+ * Validate the "customPatterns" field of the config.
+ */
+function validateCustomPatternsField(value: unknown, errors: string[]): void {
+  if (!Array.isArray(value)) {
+    errors.push('"customPatterns" must be an array');
+    return;
+  }
+  value.forEach((p: unknown, i: number) => validateCustomPattern(p, i, errors));
+}
+
+/**
  * Validate a .techdebtrc.json configuration file
  */
 export async function handleValidateConfig(args: unknown): Promise<{ content: Array<{ type: string; text: string }> }> {
@@ -70,91 +176,18 @@ export async function handleValidateConfig(args: unknown): Promise<{ content: Ar
     }
   }
 
-  if ('ignore' in config) {
-    if (!Array.isArray(config.ignore)) {
-      errors.push('"ignore" must be an array of glob strings');
-    } else if (config.ignore.some(v => typeof v !== 'string')) {
-      errors.push('"ignore" array must contain only strings');
-    }
-  }
+  validateStringArrayField('ignore', config, errors);
+  validateStringArrayField('include', config, errors);
+  validateRulesField(config, errors, warnings);
+  validateSeverityField(config, errors);
+  validateRuleExclusionsField(config, errors);
 
-  if ('include' in config) {
-    if (!Array.isArray(config.include)) {
-      errors.push('"include" must be an array of glob strings');
-    } else if (config.include.some(v => typeof v !== 'string')) {
-      errors.push('"include" array must contain only strings');
-    }
-  }
-
-  if ('rules' in config) {
-    if (!isRecord(config.rules)) {
-      errors.push('"rules" must be an object');
-    } else {
-      const rules = config.rules;
-      for (const key of Object.keys(rules)) {
-        if (!VALID_RULE_KEYS.has(key)) warnings.push(`Unknown rule key: "${key}"`);
-      }
-      for (const key of VALID_RULE_KEYS) {
-        if (key in rules && typeof rules[key] !== 'number') {
-          errors.push(`"rules.${key}" must be a number`);
-        }
-      }
-    }
-  }
-
-  if ('severity' in config) {
-    if (!isRecord(config.severity)) {
-      errors.push('"severity" must be an object');
-    } else {
-      const severity = config.severity;
-      for (const [rule, level] of Object.entries(severity)) {
-        if (typeof level !== 'string' || !VALID_SEVERITIES.has(level)) {
-          errors.push(`"severity.${rule}" has invalid value "${level}" — must be a string: low, medium, high, critical`);
-        }
-      }
-    }
-  }
-
-  if ('ruleExclusions' in config) {
-    if (!isRecord(config.ruleExclusions)) {
-      errors.push('"ruleExclusions" must be an object mapping rule names to arrays of glob strings');
-    } else {
-      const exclusions = config.ruleExclusions;
-      for (const [rule, patterns] of Object.entries(exclusions)) {
-        if (!Array.isArray(patterns)) {
-          errors.push(`"ruleExclusions.${rule}" must be an array of glob strings`);
-        } else if (patterns.some(v => typeof v !== 'string')) {
-          errors.push(`"ruleExclusions.${rule}" array must contain only strings`);
-        }
-      }
-    }
-  }
-
-  if ('languageOverrides' in config) {
-    if (!isRecord(config.languageOverrides)) {
-      errors.push('"languageOverrides" must be an object keyed by language name');
-    }
+  if ('languageOverrides' in config && !isRecord(config.languageOverrides)) {
+    errors.push('"languageOverrides" must be an object keyed by language name');
   }
 
   if ('customPatterns' in config) {
-    if (!Array.isArray(config.customPatterns)) {
-      errors.push('"customPatterns" must be an array');
-    } else {
-      config.customPatterns.forEach((p: unknown, i: number) => {
-        if (!isRecord(p)) {
-          errors.push(`customPatterns[${i}]: must be an object`);
-          return;
-        }
-        if (!isCustomPatternShape(p)) {
-          errors.push(`customPatterns[${i}]: missing required fields (id, pattern, severity, category, message)`);
-          return;
-        }
-        const result = CustomRulesEngine.validatePattern(p);
-        if (!result.valid) {
-          result.errors.forEach(e => errors.push(`customPatterns[${i}] (${p.id}): ${e}`));
-        }
-      });
-    }
+    validateCustomPatternsField(config.customPatterns, errors);
   }
 
   if (errors.length === 0 && warnings.length === 0) {

--- a/src/server/dependencyHandlers.ts
+++ b/src/server/dependencyHandlers.ts
@@ -130,6 +130,40 @@ async function validateDirectoryPath(projectPath: string): Promise<void> {
 const SKIP_DIRS = new Set(['node_modules', '.git', 'dist', 'build', 'target', '.venv', '__pycache__']);
 
 /**
+ * Check if a file entry is a package manifest that should be collected.
+ */
+function isPackageManifest(entry: string, targetFiles: string[]): boolean {
+  return targetFiles.includes(entry) || entry.endsWith('.csproj');
+}
+
+/**
+ * Process a single directory entry during package file discovery.
+ */
+async function processEntry(
+  entry: string,
+  dir: string,
+  targetFiles: string[],
+  results: string[],
+  scanErrors: string[],
+  maxDepth: number,
+  currentDepth: number,
+): Promise<void> {
+  if (SKIP_DIRS.has(entry)) return;
+
+  const fullPath = join(dir, entry);
+  const entryStats = await stat(fullPath);
+
+  if (entryStats.isDirectory()) {
+    await findPackageFiles(fullPath, targetFiles, results, scanErrors, maxDepth, currentDepth + 1);
+    return;
+  }
+
+  if (entryStats.isFile() && isPackageManifest(entry, targetFiles)) {
+    results.push(fullPath);
+  }
+}
+
+/**
  * Recursively discover package manifest files in a directory tree.
  * Skips common non-source directories (node_modules, .git, dist, etc.) and
  * limits traversal depth to avoid runaway recursion in deep trees.
@@ -152,22 +186,8 @@ async function findPackageFiles(
 
   try {
     const entries = await readdir(dir);
-
     for (const entry of entries) {
-      if (SKIP_DIRS.has(entry)) {
-        continue;
-      }
-
-      const fullPath = join(dir, entry);
-      const stats = await stat(fullPath);
-
-      if (stats.isDirectory()) {
-        await findPackageFiles(fullPath, targetFiles, results, scanErrors, maxDepth, currentDepth + 1);
-      } else if (stats.isFile()) {
-        if (targetFiles.includes(entry) || entry.endsWith('.csproj')) {
-          results.push(fullPath);
-        }
-      }
+      await processEntry(entry, dir, targetFiles, results, scanErrors, maxDepth, currentDepth);
     }
   } catch (error) {
     scanErrors.push(`${dir}: ${error instanceof Error ? error.message : String(error)}`);

--- a/src/server/handlers.ts
+++ b/src/server/handlers.ts
@@ -35,6 +35,53 @@ import {
 type ToolResponse = { content: Array<{ type: string; text: string }> };
 
 /**
+ * Dispatch a tool call by name to the appropriate handler.
+ */
+async function dispatchTool(
+  name: string,
+  args: Record<string, unknown>,
+  engine: AnalysisEngine,
+  customRulesEngine: CustomRulesEngine,
+): Promise<ToolResponse> {
+  switch (name) {
+    case 'analyze_project':
+      return handleAnalyzeProject(engine, args);
+    case 'analyze_file':
+      return handleAnalyzeFile(args);
+    case 'get_debt_summary':
+      return handleGetDebtSummary(engine, args);
+    case 'get_sqale_metrics':
+      return handleGetSqaleMetrics(engine, args);
+    case 'list_supported_languages':
+      return handleListSupportedLanguages();
+    case 'get_recommendations':
+      return handleGetRecommendations(engine, args);
+    case 'get_issues_by_severity':
+      return handleGetIssuesBySeverity(engine, args);
+    case 'get_issues_by_category':
+      return handleGetIssuesByCategory(engine, args);
+    case 'add_custom_rule':
+      return handleAddCustomRule(customRulesEngine, args);
+    case 'remove_custom_rule':
+      return handleRemoveCustomRule(customRulesEngine, args);
+    case 'list_custom_rules':
+      return handleListCustomRules(customRulesEngine);
+    case 'execute_custom_rules':
+      return handleExecuteCustomRules(customRulesEngine, args);
+    case 'validate_custom_pattern':
+      return handleValidateCustomPattern(args);
+    case 'check_dependencies':
+      return handleCheckDependencies(args);
+    case 'validate_config':
+      return handleValidateConfig(args);
+    case 'get_vulnerability_report':
+      return handleGetVulnerabilityReport(args);
+    default:
+      throw new McpError(ErrorCode.MethodNotFound, `Unknown tool: ${name}`);
+  }
+}
+
+/**
  * Attach all tool handlers to a given McpServer instance.
  */
 export function attachHandlers(mcpServer: McpServer): void {
@@ -50,44 +97,8 @@ export function attachHandlers(mcpServer: McpServer): void {
   // Handle tool calls
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const { name, arguments: args = {} } = request.params;
-
     try {
-      switch (name) {
-        case 'analyze_project':
-          return await handleAnalyzeProject(engine, args);
-        case 'analyze_file':
-          return await handleAnalyzeFile(args);
-        case 'get_debt_summary':
-          return await handleGetDebtSummary(engine, args);
-        case 'get_sqale_metrics':
-          return await handleGetSqaleMetrics(engine, args);
-        case 'list_supported_languages':
-          return handleListSupportedLanguages();
-        case 'get_recommendations':
-          return await handleGetRecommendations(engine, args);
-        case 'get_issues_by_severity':
-          return await handleGetIssuesBySeverity(engine, args);
-        case 'get_issues_by_category':
-          return await handleGetIssuesByCategory(engine, args);
-        case 'add_custom_rule':
-          return await handleAddCustomRule(customRulesEngine, args);
-        case 'remove_custom_rule':
-          return handleRemoveCustomRule(customRulesEngine, args);
-        case 'list_custom_rules':
-          return handleListCustomRules(customRulesEngine);
-        case 'execute_custom_rules':
-          return await handleExecuteCustomRules(customRulesEngine, args);
-        case 'validate_custom_pattern':
-          return handleValidateCustomPattern(args);
-        case 'check_dependencies':
-          return await handleCheckDependencies(args);
-        case 'validate_config':
-          return await handleValidateConfig(args);
-        case 'get_vulnerability_report':
-          return await handleGetVulnerabilityReport(args);
-        default:
-          throw new McpError(ErrorCode.MethodNotFound, `Unknown tool: ${name}`);
-      }
+      return await dispatchTool(name, args, engine, customRulesEngine);
     } catch (error) {
       if (error instanceof McpError) throw error;
       const message = error instanceof Error ? error.message : 'Unknown error';

--- a/src/server/resourceHandlers.ts
+++ b/src/server/resourceHandlers.ts
@@ -10,16 +10,25 @@ import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mc
 import { Variables } from '@modelcontextprotocol/sdk/shared/uriTemplate.js';
 import { AnalysisEngine } from '../core/analysisEngine.js';
 
+type ResourceResponse = { contents: Array<{ uri: string; mimeType: string; text: string }> };
+
 /**
  * Build a resource error response for a given URI and error message.
  */
-function jsonErrorResponse(uri: URL, message: string) {
+function jsonErrorResponse(uri: URL, message: string): ResourceResponse {
+  return jsonSuccessResponse(uri, { error: message });
+}
+
+/**
+ * Build a resource success response for a given URI and data object.
+ */
+function jsonSuccessResponse(uri: URL, data: unknown): ResourceResponse {
   return {
     contents: [
       {
         uri: uri.href,
         mimeType: 'application/json',
-        text: JSON.stringify({ error: message }, null, 2),
+        text: JSON.stringify(data, null, 2),
       },
     ],
   };
@@ -32,6 +41,78 @@ function jsonErrorResponse(uri: URL, message: string) {
 function getStringVariable(variables: Variables, key: string): string | null {
   const value = variables[key];
   return typeof value === 'string' ? value : null;
+}
+
+/**
+ * Handle the debt://summary resource for a given project path.
+ */
+async function handleSummaryResource(
+  uri: URL,
+  engine: AnalysisEngine,
+  projectPath: string,
+): Promise<ResourceResponse> {
+  const report = await engine.analyzeProject({ path: projectPath });
+  const summary = {
+    timestamp: report.timestamp,
+    healthScore: report.summary.healthScore,
+    debtScore: report.summary.debtScore,
+    totalIssues: report.summary.totalIssues,
+    bySeverity: report.summary.bySeverity,
+    byCategory: report.summary.byCategory,
+    sqale: {
+      rating: report.sqale.rating,
+      totalRemediationTime: report.sqale.totalRemediationTime,
+      formattedTime: report.sqale.formattedTime,
+    },
+  };
+  return jsonSuccessResponse(uri, summary);
+}
+
+/**
+ * Handle the debt://issues resource for a given project path.
+ */
+async function handleIssuesResource(
+  uri: URL,
+  engine: AnalysisEngine,
+  projectPath: string,
+): Promise<ResourceResponse> {
+  const report = await engine.analyzeProject({ path: projectPath });
+
+  const params = uri.searchParams;
+  const severityFilter = params.get('severity');
+  const categoryFilter = params.get('category');
+  const rawLimit = parseInt(params.get('limit') ?? '100', 10);
+  const limit = Number.isFinite(rawLimit) && rawLimit > 0 ? rawLimit : 100;
+
+  let filteredIssues = report.issues;
+  if (severityFilter) {
+    filteredIssues = filteredIssues.filter((i) => i.severity === severityFilter);
+  }
+  if (categoryFilter) {
+    filteredIssues = filteredIssues.filter((i) => i.category === categoryFilter);
+  }
+
+  const result = {
+    timestamp: report.timestamp,
+    totalCount: filteredIssues.length,
+    issues: filteredIssues.slice(0, limit),
+  };
+  return jsonSuccessResponse(uri, result);
+}
+
+/**
+ * Wrap a resource handler with try/catch, returning a JSON error response on failure.
+ */
+async function withResourceErrorHandling(
+  uri: URL,
+  handler: () => Promise<ResourceResponse>,
+): Promise<ResourceResponse> {
+  try {
+    return await handler();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return jsonErrorResponse(uri, message);
+  }
 }
 
 /**
@@ -54,37 +135,7 @@ export function attachResources(mcpServer: McpServer): void {
       if (projectPath === null) {
         return jsonErrorResponse(uri, 'projectPath must be a string');
       }
-
-      try {
-        const report = await engine.analyzeProject({ path: projectPath });
-
-        const summary = {
-          timestamp: report.timestamp,
-          healthScore: report.summary.healthScore,
-          debtScore: report.summary.debtScore,
-          totalIssues: report.summary.totalIssues,
-          bySeverity: report.summary.bySeverity,
-          byCategory: report.summary.byCategory,
-          sqale: {
-            rating: report.sqale.rating,
-            totalRemediationTime: report.sqale.totalRemediationTime,
-            formattedTime: report.sqale.formattedTime,
-          },
-        };
-
-        return {
-          contents: [
-            {
-              uri: uri.href,
-              mimeType: 'application/json',
-              text: JSON.stringify(summary, null, 2),
-            },
-          ],
-        };
-      } catch (error) {
-        const message = error instanceof Error ? error.message : 'Unknown error';
-        return jsonErrorResponse(uri, message);
-      }
+      return withResourceErrorHandling(uri, () => handleSummaryResource(uri, engine, projectPath));
     }
   );
 
@@ -101,45 +152,7 @@ export function attachResources(mcpServer: McpServer): void {
       if (projectPath === null) {
         return jsonErrorResponse(uri, 'projectPath must be a string');
       }
-
-      try {
-        const report = await engine.analyzeProject({ path: projectPath });
-
-        // Parse query parameters for filtering
-        const params = uri.searchParams;
-        const severityFilter = params.get('severity');
-        const categoryFilter = params.get('category');
-        const rawLimit = parseInt(params.get('limit') ?? '100', 10);
-        const limit = Number.isFinite(rawLimit) && rawLimit > 0 ? rawLimit : 100;
-
-        let filteredIssues = report.issues;
-
-        if (severityFilter) {
-          filteredIssues = filteredIssues.filter((i) => i.severity === severityFilter);
-        }
-        if (categoryFilter) {
-          filteredIssues = filteredIssues.filter((i) => i.category === categoryFilter);
-        }
-
-        const result = {
-          timestamp: report.timestamp,
-          totalCount: filteredIssues.length,
-          issues: filteredIssues.slice(0, limit),
-        };
-
-        return {
-          contents: [
-            {
-              uri: uri.href,
-              mimeType: 'application/json',
-              text: JSON.stringify(result, null, 2),
-            },
-          ],
-        };
-      } catch (error) {
-        const message = error instanceof Error ? error.message : 'Unknown error';
-        return jsonErrorResponse(uri, message);
-      }
+      return withResourceErrorHandling(uri, () => handleIssuesResource(uri, engine, projectPath));
     }
   );
 }


### PR DESCRIPTION
## Summary
- Extracted deeply nested logic in all four affected server modules into dedicated helper functions
- Replaced nested conditionals with guard clauses and early returns throughout
- `resourceHandlers.ts`: added `jsonSuccessResponse`, `handleSummaryResource`, `handleIssuesResource`, and `withResourceErrorHandling` to reduce callback nesting from depth 7 to ≤4
- `handlers.ts`: extracted `dispatchTool` to hold the switch statement, reducing `CallToolRequestSchema` callback nesting from depth 5 to ≤4
- `dependencyHandlers.ts`: extracted `processEntry` and `isPackageManifest` from `findPackageFiles`, flattening the nested for/if/if structure
- `configValidator.ts`: extracted `validateStringArrayField`, `validateRulesField`, `validateSeverityField`, `validateRuleExclusionsField`, `validateCustomPattern`, and `validateCustomPatternsField` to flatten the main handler body

Closes #85

## Test plan
- [x] `npm test` passes (458 tests, 0 failures)
- [x] `npm run build` passes (no TypeScript errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)