### PR TITLE
test: add direct unit tests for swiftUiChecks and swiftUiChecksPhase2 modules

### DIFF
--- a/src/analyzers/__tests__/swiftUiChecks.test.ts
+++ b/src/analyzers/__tests__/swiftUiChecks.test.ts
@@ -1,0 +1,363 @@
+/**
+ * Unit tests for SwiftUI Phase-1 check helpers (swiftUiChecks.ts).
+ * These functions are also exercised indirectly through swiftAnalyzer.test.ts;
+ * this file tests each helper in isolation to achieve >80 % coverage.
+ */
+
+import {
+  checkExcessiveStateVariables,
+  checkObservedObjectMisuse,
+  checkMissingEnvironmentValidation,
+  checkCombineCircularReferences,
+  checkMissingTimerCleanup,
+  checkMissingTaskCancellation,
+  checkMainThreadSafety,
+} from '../swiftUiChecks.js';
+
+const FILE = 'test.swift';
+
+function lines(code: string): string[] {
+  return code.split('\n');
+}
+
+// ---------------------------------------------------------------------------
+// checkExcessiveStateVariables
+// ---------------------------------------------------------------------------
+
+describe('checkExcessiveStateVariables', () => {
+  it('returns no issues when @State count is at the threshold (5)', () => {
+    const code = `
+struct SmallView: View {
+  @State private var a = ""
+  @State private var b = ""
+  @State private var c = ""
+  @State private var d = ""
+  @State private var e = ""
+  var body: some View { Text("ok") }
+}`;
+    const issues = checkExcessiveStateVariables(FILE, lines(code));
+    expect(issues).toHaveLength(0);
+  });
+
+  it('reports an issue when @State count exceeds 5', () => {
+    const code = `
+struct BigView: View {
+  @State private var a = ""
+  @State private var b = ""
+  @State private var c = ""
+  @State private var d = ""
+  @State private var e = ""
+  @State private var f = ""
+  var body: some View { Text("ok") }
+}`;
+    const issues = checkExcessiveStateVariables(FILE, lines(code));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].rule).toBe('swiftui-excessive-state');
+    expect(issues[0].severity).toBe('medium');
+    expect(issues[0].description).toContain('BigView');
+  });
+
+  it('tracks @State counts per-view independently', () => {
+    const code = `
+struct TinyView: View {
+  @State private var x = ""
+  var body: some View { Text("x") }
+}
+struct HugeView: View {
+  @State private var a = ""
+  @State private var b = ""
+  @State private var c = ""
+  @State private var d = ""
+  @State private var e = ""
+  @State private var f = ""
+  @State private var g = ""
+  var body: some View { Text("huge") }
+}`;
+    const issues = checkExcessiveStateVariables(FILE, lines(code));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].description).toContain('HugeView');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkObservedObjectMisuse
+// ---------------------------------------------------------------------------
+
+describe('checkObservedObjectMisuse', () => {
+  it('flags @ObservedObject with inline initialization', () => {
+    const code = `struct Foo: View {
+  @ObservedObject var vm = MyViewModel()
+}`;
+    const issues = checkObservedObjectMisuse(FILE, lines(code));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].rule).toBe('swiftui-state-object-misuse');
+    expect(issues[0].severity).toBe('high');
+  });
+
+  it('does not flag @ObservedObject passed from outside (no = initialiser)', () => {
+    const code = `struct Foo: View {
+  @ObservedObject var vm: MyViewModel
+}`;
+    const issues = checkObservedObjectMisuse(FILE, lines(code));
+    expect(issues).toHaveLength(0);
+  });
+
+  it('ignores commented-out lines', () => {
+    const code = `struct Foo: View {
+  // @ObservedObject var vm = MyViewModel()
+}`;
+    const issues = checkObservedObjectMisuse(FILE, lines(code));
+    expect(issues).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkMissingEnvironmentValidation
+// ---------------------------------------------------------------------------
+
+describe('checkMissingEnvironmentValidation', () => {
+  it('flags force-unwrap of an @Environment variable', () => {
+    const code = `struct DetailView: View {
+  @Environment(\\.dismiss) var dismissAction
+  var body: some View {
+    Button("Close") { dismissAction! }
+  }
+}`;
+    const issues = checkMissingEnvironmentValidation(FILE, lines(code));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].rule).toBe('swiftui-env-validation');
+    expect(issues[0].severity).toBe('high');
+  });
+
+  it('does not flag safe usage of @Environment variable', () => {
+    const code = `struct DetailView: View {
+  @Environment(\\.dismiss) var dismissAction
+  var body: some View {
+    Button("Close") { dismissAction() }
+  }
+}`;
+    const issues = checkMissingEnvironmentValidation(FILE, lines(code));
+    expect(issues).toHaveLength(0);
+  });
+
+  it('ignores force-unwrap in comments', () => {
+    const code = `struct DetailView: View {
+  @Environment(\\.dismiss) var dismissAction
+  var body: some View {
+    // Button("X") { dismissAction! }
+    Text("ok")
+  }
+}`;
+    const issues = checkMissingEnvironmentValidation(FILE, lines(code));
+    expect(issues).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkCombineCircularReferences
+// ---------------------------------------------------------------------------
+
+describe('checkCombineCircularReferences', () => {
+  it('flags .sink followed by self reference without [weak self]', () => {
+    const code = `func load() {
+  publisher
+    .sink { completion in
+      self.handleCompletion(completion)
+    }
+    .store(in: &cancellables)
+}`;
+    const issues = checkCombineCircularReferences(FILE, lines(code));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].rule).toBe('swiftui-combine-circular-ref');
+    expect(issues[0].severity).toBe('high');
+  });
+
+  it('does not flag .sink with [weak self] capture list', () => {
+    const code = `func load() {
+  publisher
+    .sink { [weak self] completion in
+      self?.handleCompletion(completion)
+    }
+    .store(in: &cancellables)
+}`;
+    const issues = checkCombineCircularReferences(FILE, lines(code));
+    expect(issues).toHaveLength(0);
+  });
+
+  it('does not flag .sink with [unowned self] capture list', () => {
+    const code = `func load() {
+  publisher
+    .sink { [unowned self] completion in
+      self.handleCompletion(completion)
+    }
+    .store(in: &cancellables)
+}`;
+    const issues = checkCombineCircularReferences(FILE, lines(code));
+    expect(issues).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkMissingTimerCleanup
+// ---------------------------------------------------------------------------
+
+describe('checkMissingTimerCleanup', () => {
+  it('flags Timer.scheduledTimer without invalidate in onDisappear', () => {
+    const code = `struct TimerView: View {
+  var body: some View {
+    Text("tick")
+      .onAppear {
+        Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in }
+      }
+  }
+}`;
+    const issues = checkMissingTimerCleanup(FILE, lines(code));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].rule).toBe('swiftui-timer-cleanup');
+    expect(issues[0].severity).toBe('medium');
+  });
+
+  it('does not flag Timer when onDisappear + invalidate are present nearby', () => {
+    const code = `struct TimerView: View {
+  var body: some View {
+    Text("tick")
+      .onAppear {
+        Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in }
+      }
+      .onDisappear {
+        invalidate()
+      }
+  }
+}`;
+    const issues = checkMissingTimerCleanup(FILE, lines(code));
+    expect(issues).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkMissingTaskCancellation
+// ---------------------------------------------------------------------------
+
+describe('checkMissingTaskCancellation', () => {
+  it('flags Task{} without stored handle or @MainActor', () => {
+    const code = `struct AsyncView: View {
+  var body: some View {
+    Text("async")
+      .onAppear {
+        Task {
+          await doWork()
+        }
+      }
+  }
+}`;
+    const issues = checkMissingTaskCancellation(FILE, lines(code));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].rule).toBe('swiftui-task-cancellation');
+    expect(issues[0].severity).toBe('medium');
+  });
+
+  it('does not flag Task when handle is stored with let task =', () => {
+    const code = `struct AsyncView: View {
+  var body: some View {
+    Text("async")
+      .onAppear {
+        let task = Task {
+          await doWork()
+        }
+        _ = task
+      }
+  }
+}`;
+    const issues = checkMissingTaskCancellation(FILE, lines(code));
+    expect(issues).toHaveLength(0);
+  });
+
+  it('does not flag Task when @MainActor appears within 3 lines before Task{', () => {
+    // @MainActor must be within 3 lines before Task{ for the check to skip the issue
+    const code = `struct AsyncView: View {
+  var body: some View {
+    Text("async")
+      .onAppear {
+        // Run on main actor
+        @MainActor func work() async { await doWork() }
+        Task {
+          await work()
+        }
+      }
+  }
+}`;
+    const issues = checkMissingTaskCancellation(FILE, lines(code));
+    expect(issues).toHaveLength(0);
+  });
+
+  it('ignores commented-out Task lines', () => {
+    const code = `struct AsyncView: View {
+  var body: some View {
+    Text("async")
+      .onAppear {
+        // Task {
+        //   await doWork()
+        // }
+      }
+  }
+}`;
+    const issues = checkMissingTaskCancellation(FILE, lines(code));
+    expect(issues).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkMainThreadSafety
+// ---------------------------------------------------------------------------
+
+describe('checkMainThreadSafety', () => {
+  it('flags Task{} followed immediately by self. without @MainActor', () => {
+    const code = `struct Foo: View {
+  @State private var items: [String] = []
+  var body: some View {
+    Text("x")
+      .onAppear {
+        Task {
+          self.items = await fetch()
+        }
+      }
+  }
+}`;
+    const issues = checkMainThreadSafety(FILE, lines(code));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].rule).toBe('swiftui-main-thread-safety');
+    expect(issues[0].severity).toBe('high');
+  });
+
+  it('does not flag Task{} with @MainActor annotation nearby', () => {
+    const code = `struct Foo: View {
+  @State private var items: [String] = []
+  var body: some View {
+    Text("x")
+      .onAppear {
+        Task { @MainActor in
+          self.items = await fetch()
+        }
+      }
+  }
+}`;
+    const issues = checkMainThreadSafety(FILE, lines(code));
+    expect(issues).toHaveLength(0);
+  });
+
+  it('does not flag Task{} with DispatchQueue.main usage', () => {
+    const code = `struct Foo: View {
+  @State private var items: [String] = []
+  var body: some View {
+    Text("x")
+      .onAppear {
+        Task {
+          DispatchQueue.main.async { self.items = [] }
+        }
+      }
+  }
+}`;
+    const issues = checkMainThreadSafety(FILE, lines(code));
+    expect(issues).toHaveLength(0);
+  });
+});

--- a/src/analyzers/__tests__/swiftUiChecksPhase2.test.ts
+++ b/src/analyzers/__tests__/swiftUiChecksPhase2.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Unit tests for SwiftUI Phase-2 check helpers (swiftUiChecksPhase2.ts).
+ * Each helper is exercised in isolation to achieve >80 % direct coverage.
+ */
+
+import {
+  checkMissingIdModifier,
+  checkExpensiveViewBodyCalculations,
+  checkAnyViewMisuse,
+  checkNavigationLinkIssues,
+  checkGeometryReaderMisuse,
+  checkRetainCyclesInClosures,
+  checkDeepViewNesting,
+} from '../swiftUiChecksPhase2.js';
+
+const FILE = 'test.swift';
+
+function lines(code: string): string[] {
+  return code.split('\n');
+}
+
+// ---------------------------------------------------------------------------
+// checkMissingIdModifier
+// ---------------------------------------------------------------------------
+
+describe('checkMissingIdModifier', () => {
+  it('flags ForEach over "items" without .id() or id: parameter', () => {
+    const code = `struct Foo: View {
+  var body: some View {
+    ForEach(items) { item in
+      Text(item.name)
+    }
+  }
+}`;
+    const issues = checkMissingIdModifier(FILE, lines(code));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].rule).toBe('swiftui-missing-id');
+    expect(issues[0].severity).toBe('medium');
+  });
+
+  it('does not flag ForEach with explicit id: parameter', () => {
+    const code = `struct Foo: View {
+  var body: some View {
+    ForEach(items, id: \\.self) { item in
+      Text(item.name)
+    }
+  }
+}`;
+    const issues = checkMissingIdModifier(FILE, lines(code));
+    expect(issues).toHaveLength(0);
+  });
+
+  it('does not flag ForEach with .id() modifier', () => {
+    const code = `struct Foo: View {
+  var body: some View {
+    ForEach(items) { item in
+      Text(item.name).id(item.id)
+    }
+  }
+}`;
+    const issues = checkMissingIdModifier(FILE, lines(code));
+    expect(issues).toHaveLength(0);
+  });
+
+  it('does not flag ForEach over unrelated variable names', () => {
+    const code = `struct Foo: View {
+  var body: some View {
+    ForEach(numbers) { n in
+      Text("\\(n)")
+    }
+  }
+}`;
+    // "numbers" contains neither "items" nor "data" as a substring
+    const issues = checkMissingIdModifier(FILE, lines(code));
+    expect(issues).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkExpensiveViewBodyCalculations
+// ---------------------------------------------------------------------------
+
+describe('checkExpensiveViewBodyCalculations', () => {
+  it('flags .reduce() inside var body', () => {
+    const code = `struct SumView: View {
+  let nums: [Int]
+  var body: some View {
+    Text("sum: \\(nums.reduce(0, +))")
+  }
+}`;
+    const issues = checkExpensiveViewBodyCalculations(FILE, lines(code));
+    expect(issues.length).toBeGreaterThanOrEqual(1);
+    expect(issues[0].rule).toBe('swiftui-expensive-calculation');
+    expect(issues[0].severity).toBe('medium');
+    expect(issues[0].category).toBe('performance');
+  });
+
+  it('flags .sorted inside var body', () => {
+    const code = `struct SortedView: View {
+  let items: [String]
+  var body: some View {
+    List(items.sorted(), id: \\.self) { Text($0) }
+  }
+}`;
+    const issues = checkExpensiveViewBodyCalculations(FILE, lines(code));
+    expect(issues.length).toBeGreaterThanOrEqual(1);
+    expect(issues[0].rule).toBe('swiftui-expensive-calculation');
+  });
+
+  it('does not flag .sorted outside var body', () => {
+    const code = `struct SortedView: View {
+  var sortedItems: [String] { items.sorted() }
+  let items: [String]
+  var body: some View {
+    List(sortedItems, id: \\.self) { Text($0) }
+  }
+}`;
+    const issues = checkExpensiveViewBodyCalculations(FILE, lines(code));
+    expect(issues).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkAnyViewMisuse
+// ---------------------------------------------------------------------------
+
+describe('checkAnyViewMisuse', () => {
+  it('flags AnyView( usage', () => {
+    const code = `func makeView() -> some View {
+  AnyView(Text("hello"))
+}`;
+    const issues = checkAnyViewMisuse(FILE, lines(code));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].rule).toBe('swiftui-anyview-misuse');
+    expect(issues[0].severity).toBe('medium');
+  });
+
+  it('ignores AnyView in a comment', () => {
+    const code = `// Use AnyView( only when necessary
+struct Foo: View {
+  var body: some View { Text("ok") }
+}`;
+    const issues = checkAnyViewMisuse(FILE, lines(code));
+    expect(issues).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkNavigationLinkIssues
+// ---------------------------------------------------------------------------
+
+describe('checkNavigationLinkIssues', () => {
+  it('flags NavigationLink with destination: but no isActive/tag/selection', () => {
+    const code = `struct Foo: View {
+  var body: some View {
+    NavigationLink(
+      destination: DetailView()
+    ) {
+      Text("Go")
+    }
+  }
+}`;
+    const issues = checkNavigationLinkIssues(FILE, lines(code));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].rule).toBe('swiftui-navigationlink-deprecated');
+    expect(issues[0].severity).toBe('medium');
+  });
+
+  it('does not flag NavigationLink with isActive:', () => {
+    const code = `struct Foo: View {
+  @State var active = false
+  var body: some View {
+    NavigationLink(destination: DetailView(), isActive: $active) {
+      Text("Go")
+    }
+  }
+}`;
+    const issues = checkNavigationLinkIssues(FILE, lines(code));
+    expect(issues).toHaveLength(0);
+  });
+
+  it('does not flag NavigationLink without destination: keyword', () => {
+    const code = `struct Foo: View {
+  var body: some View {
+    NavigationLink("Go", value: someValue)
+  }
+}`;
+    const issues = checkNavigationLinkIssues(FILE, lines(code));
+    expect(issues).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkGeometryReaderMisuse
+// ---------------------------------------------------------------------------
+
+describe('checkGeometryReaderMisuse', () => {
+  it('flags GeometryReader immediately after var body without .frame()', () => {
+    const code = `struct Foo: View {
+  var body: some View {
+    GeometryReader { geo in
+      Text("size: \\(geo.size.width)")
+    }
+  }
+}`;
+    const issues = checkGeometryReaderMisuse(FILE, lines(code));
+    expect(issues.length).toBeGreaterThanOrEqual(1);
+    expect(issues[0].rule).toBe('swiftui-geometryreader-root');
+    expect(issues[0].severity).toBe('medium');
+    expect(issues[0].category).toBe('performance');
+  });
+
+  it('does not flag GeometryReader paired with .frame()', () => {
+    const code = `struct Foo: View {
+  var body: some View {
+    GeometryReader { geo in
+      Text("hi").frame(width: geo.size.width)
+    }
+  }
+}`;
+    const issues = checkGeometryReaderMisuse(FILE, lines(code));
+    expect(issues).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkRetainCyclesInClosures
+// ---------------------------------------------------------------------------
+
+describe('checkRetainCyclesInClosures', () => {
+  it('flags .onChange capturing self without [weak self] in a class', () => {
+    const code = `class MyVC: UIViewController {
+  func setup() {
+    view.onChange(of: value) { _ in
+      self.update()
+    }
+  }
+}`;
+    const issues = checkRetainCyclesInClosures(FILE, lines(code));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].rule).toBe('swiftui-retain-cycle-closure');
+    expect(issues[0].severity).toBe('high');
+  });
+
+  it('does not flag .onChange with [weak self]', () => {
+    const code = `class MyVC: UIViewController {
+  func setup() {
+    view.onChange(of: value) { [weak self] _ in
+      self?.update()
+    }
+  }
+}`;
+    const issues = checkRetainCyclesInClosures(FILE, lines(code));
+    expect(issues).toHaveLength(0);
+  });
+
+  it('skips struct-based SwiftUI views (value types cannot have retain cycles)', () => {
+    const code = `struct ContentView: View {
+  var body: some View {
+    Text("hi")
+      .onChange(of: someValue) { _ in
+        self.doSomething()
+      }
+  }
+  func doSomething() {}
+}`;
+    const issues = checkRetainCyclesInClosures(FILE, lines(code));
+    expect(issues).toHaveLength(0);
+  });
+
+  it('flags .onReceive capturing self in a class', () => {
+    const code = `class Presenter: NSObject {
+  func bind() {
+    publisher.onReceive(pub) { _ in
+      self.reload()
+    }
+  }
+}`;
+    const issues = checkRetainCyclesInClosures(FILE, lines(code));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].rule).toBe('swiftui-retain-cycle-closure');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkDeepViewNesting
+// ---------------------------------------------------------------------------
+
+describe('checkDeepViewNesting', () => {
+  it('flags view body with nesting depth exceeding 6', () => {
+    // Build a body with > 6 levels of { nesting
+    const code = `struct DeeplyNested: View {
+  var body: some View {
+    VStack {
+      HStack {
+        VStack {
+          HStack {
+            VStack {
+              HStack {
+                VStack {
+                  Text("deep")
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}`;
+    const issues = checkDeepViewNesting(FILE, lines(code));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].rule).toBe('swiftui-deep-nesting');
+    expect(issues[0].severity).toBe('medium');
+    expect(issues[0].category).toBe('maintainability');
+  });
+
+  it('does not flag a flat view body', () => {
+    const code = `struct ShallowView: View {
+  var body: some View {
+    VStack {
+      Text("a")
+      Text("b")
+    }
+  }
+}`;
+    const issues = checkDeepViewNesting(FILE, lines(code));
+    expect(issues).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `swiftUiChecks.test.ts` with 20 isolated tests covering all 7 Phase-1 helper functions (`checkExcessiveStateVariables`, `checkObservedObjectMisuse`, `checkMissingEnvironmentValidation`, `checkCombineCircularReferences`, `checkMissingTimerCleanup`, `checkMissingTaskCancellation`, `checkMainThreadSafety`)
- Adds `swiftUiChecksPhase2.test.ts` with 21 isolated tests covering all 7 Phase-2 helper functions (`checkMissingIdModifier`, `checkExpensiveViewBodyCalculations`, `checkAnyViewMisuse`, `checkNavigationLinkIssues`, `checkGeometryReaderMisuse`, `checkRetainCyclesInClosures`, `checkDeepViewNesting`)
- The `swiftAnalyzer.ts` split was completed in PR #111; these tests close the coverage gap for the two extracted modules

Closes #96

## Test plan
- [x] `npm test` passes (520 tests total, 499 passing, 21 todo)
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)