### PR TITLE
fix: tighten Ruby eval usage detection

### DIFF
--- a/src/analyzers/__tests__/rubyAnalyzer.test.ts
+++ b/src/analyzers/__tests__/rubyAnalyzer.test.ts
@@ -61,6 +61,31 @@ describe('RubyAnalyzer', () => {
     );
   });
 
+  it('does not report Ruby metaprogramming eval methods as bare eval usage', async () => {
+    const code = `
+      instance_eval(&block)
+      class_eval("def generated_class_method; end")
+      module_eval("def generated; end")
+    `;
+    const result = await analyzer.analyze('test.rb', code);
+    const evalIssues = result.issues.filter(i => i.rule === 'eval-usage');
+    expect(evalIssues).toHaveLength(0);
+  });
+
+  it('detects qualified Kernel.eval() usage', async () => {
+    const code = `
+      code = "puts 'hello'"
+      Kernel.eval(code)
+    `;
+    const result = await analyzer.analyze('test.rb', code);
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({
+        rule: 'eval-usage',
+        severity: 'critical',
+      })
+    );
+  });
+
   it('detects global variables', async () => {
     const code = `
       $global_var = 42
@@ -139,4 +164,3 @@ describe('RubyAnalyzer', () => {
     expect(result.issues.length).toBeGreaterThan(3);
   });
 });
-

--- a/src/analyzers/rubyAnalyzer.ts
+++ b/src/analyzers/rubyAnalyzer.ts
@@ -52,7 +52,7 @@ export class RubyAnalyzer extends BaseAnalyzer {
     }));
 
     // eval() usage (code execution)
-    issues.push(...this.checkPattern(filePath, content, /eval\s*\(/g, {
+    issues.push(...this.checkPattern(filePath, content, /(?<!\w)eval\s*\(/g, {
       category: 'security',
       severity: 'critical',
       title: 'eval() usage found',
@@ -102,4 +102,3 @@ export class RubyAnalyzer extends BaseAnalyzer {
     return issues;
   }
 }
-


### PR DESCRIPTION
Part of #225 (Ruby portion — PHP follow-up tracked in the issue).

## Summary

- tighten Ruby `eval-usage` detection so `_eval` metaprogramming helpers are not reported as bare `eval(...)`

## Changes

- require `eval` to start at a non-identifier boundary before reporting `eval-usage`
- add regression coverage for `instance_eval(...)`, `class_eval(...)`, and `module_eval(...)`
- keep true-positive coverage for both bare `eval(...)` and qualified `Kernel.eval(...)`

The Ruby analyzer was matching any `eval(` substring, including the suffix of method names such as `instance_eval(`. That caused normal Ruby metaprogramming helpers to be reported as critical `eval-usage` findings. The new boundary excludes `_eval` method names while continuing to catch bare and qualified `eval(...)` calls.

## Risk

Low. The change is limited to the Ruby `eval-usage` pattern and regression tests. The analyzer remains regex-based, so broader parsing behavior is unchanged.

## Verification

```bash
npm ci
npm test -- --runInBand
npm run typecheck
npm run lint
npm run build
```
