### PR TITLE
fix: tighten PHP usage detection boundaries

### DIFF
--- a/src/analyzers/__tests__/phpAnalyzer.test.ts
+++ b/src/analyzers/__tests__/phpAnalyzer.test.ts
@@ -89,6 +89,17 @@ describe('PhpAnalyzer', () => {
     expect(evalIssues).toHaveLength(0);
   });
 
+  it('does not detect eval-usage for PHP variable function calls', async () => {
+    const code = `
+      <?php
+      $eval = $callback;
+      $eval($template);
+    `;
+    const result = await analyzer.analyze('test.php', code);
+    const evalIssues = result.issues.filter(i => i.rule === 'eval-usage');
+    expect(evalIssues).toHaveLength(0);
+  });
+
   it('detects error suppression operator', async () => {
     const code = `
       <?php
@@ -143,6 +154,17 @@ describe('PhpAnalyzer', () => {
 
       $result = custom_extract($payload);
       $builder->safe_extract($payload);
+    `;
+    const result = await analyzer.analyze('test.php', code);
+    const extractIssues = result.issues.filter(i => i.rule === 'extract-usage');
+    expect(extractIssues).toHaveLength(0);
+  });
+
+  it('does not detect extract-usage for PHP variable function calls', async () => {
+    const code = `
+      <?php
+      $extract = $callback;
+      $extract($payload);
     `;
     const result = await analyzer.analyze('test.php', code);
     const extractIssues = result.issues.filter(i => i.rule === 'extract-usage');

--- a/src/analyzers/__tests__/phpAnalyzer.test.ts
+++ b/src/analyzers/__tests__/phpAnalyzer.test.ts
@@ -74,6 +74,21 @@ describe('PhpAnalyzer', () => {
     );
   });
 
+  it('does not detect eval-usage inside longer PHP function names', async () => {
+    const code = `
+      <?php
+      function custom_eval($code) {
+        return $code;
+      }
+
+      $result = custom_eval($template);
+      $builder->safe_eval($template);
+    `;
+    const result = await analyzer.analyze('test.php', code);
+    const evalIssues = result.issues.filter(i => i.rule === 'eval-usage');
+    expect(evalIssues).toHaveLength(0);
+  });
+
   it('detects error suppression operator', async () => {
     const code = `
       <?php
@@ -167,4 +182,3 @@ describe('PhpAnalyzer', () => {
     expect(result.issues.length).toBeGreaterThan(4);
   });
 });
-

--- a/src/analyzers/__tests__/phpAnalyzer.test.ts
+++ b/src/analyzers/__tests__/phpAnalyzer.test.ts
@@ -134,6 +134,21 @@ describe('PhpAnalyzer', () => {
     );
   });
 
+  it('does not detect extract-usage inside longer PHP function names', async () => {
+    const code = `
+      <?php
+      function custom_extract($array) {
+        return $array;
+      }
+
+      $result = custom_extract($payload);
+      $builder->safe_extract($payload);
+    `;
+    const result = await analyzer.analyze('test.php', code);
+    const extractIssues = result.issues.filter(i => i.rule === 'extract-usage');
+    expect(extractIssues).toHaveLength(0);
+  });
+
   it('detects @phpcs:ignore comments', async () => {
     const code = `
       <?php

--- a/src/analyzers/phpAnalyzer.ts
+++ b/src/analyzers/phpAnalyzer.ts
@@ -88,7 +88,7 @@ export class PhpAnalyzer extends BaseAnalyzer {
     }));
 
     // extract() function
-    issues.push(...this.checkPattern(filePath, content, /extract\s*\(/g, {
+    issues.push(...this.checkPattern(filePath, content, /(?<!\w)extract\s*\(/g, {
       category: 'security',
       severity: 'high',
       title: 'extract() function found',

--- a/src/analyzers/phpAnalyzer.ts
+++ b/src/analyzers/phpAnalyzer.ts
@@ -52,7 +52,7 @@ export class PhpAnalyzer extends BaseAnalyzer {
     }));
 
     // eval() usage (code execution)
-    issues.push(...this.checkPattern(filePath, content, /eval\s*\(/g, {
+    issues.push(...this.checkPattern(filePath, content, /(?<!\w)eval\s*\(/g, {
       category: 'security',
       severity: 'critical',
       title: 'eval() usage found',
@@ -114,4 +114,3 @@ export class PhpAnalyzer extends BaseAnalyzer {
     return issues;
   }
 }
-

--- a/src/analyzers/phpAnalyzer.ts
+++ b/src/analyzers/phpAnalyzer.ts
@@ -52,7 +52,7 @@ export class PhpAnalyzer extends BaseAnalyzer {
     }));
 
     // eval() usage (code execution)
-    issues.push(...this.checkPattern(filePath, content, /(?<!\w)eval\s*\(/g, {
+    issues.push(...this.checkPattern(filePath, content, /(?<![\w$])eval\s*\(/g, {
       category: 'security',
       severity: 'critical',
       title: 'eval() usage found',
@@ -88,7 +88,7 @@ export class PhpAnalyzer extends BaseAnalyzer {
     }));
 
     // extract() function
-    issues.push(...this.checkPattern(filePath, content, /(?<!\w)extract\s*\(/g, {
+    issues.push(...this.checkPattern(filePath, content, /(?<![\w$])extract\s*\(/g, {
       category: 'security',
       severity: 'high',
       title: 'extract() function found',


### PR DESCRIPTION
Fixes #225.

## Summary

- tighten PHP security usage detection so helper names like `custom_eval(...)` / `safe_extract(...)` and variable-function calls like `$eval(...)` / `$extract(...)` are not reported as bare `eval(...)` or `extract(...)`

## Changes

- require `eval` to start at a non-identifier boundary before reporting `eval-usage`
- require `extract` to start at a non-identifier boundary before reporting `extract-usage`
- add PHP regression coverage for longer function and method names ending in `_eval`
- add PHP regression coverage for longer function and method names ending in `_extract`
- add PHP regression coverage for `$eval(...)` and `$extract(...)` variable-function calls
- keep true-positive coverage for bare `eval(...)` and `extract(...)`

The PHP analyzer was still matching security-rule function names inside longer identifiers or immediately after a `$` variable-function prefix. That could report normal helper names or variable callbacks as `eval-usage` / `extract-usage` findings. The new boundaries exclude identifier and `$` prefixes while continuing to catch direct `eval(...)` and `extract(...)` calls.

## Risk

Low. The change is limited to PHP `eval-usage` / `extract-usage` patterns and regression tests. The analyzer remains regex-based, so broader parsing behavior is unchanged.

## Verification

```bash
npm ci
npm test -- src/analyzers/__tests__/phpAnalyzer.test.ts --runInBand
npm test -- --runInBand
npm run typecheck
npm run lint
npm run build
```
